### PR TITLE
Fix missing #include <cmath>

### DIFF
--- a/src/char_model_trainer.cc
+++ b/src/char_model_trainer.cc
@@ -14,6 +14,8 @@
 
 #include "char_model_trainer.h"
 
+#include <cmath>
+
 #include "char_model.h"
 #include "util.h"
 

--- a/src/unigram_model.cc
+++ b/src/unigram_model.cc
@@ -15,6 +15,7 @@
 #include "unigram_model.h"
 
 #include <cfloat>
+#include <cmath>
 #include <map>
 #include <queue>
 #include <string>

--- a/src/word_model_trainer.cc
+++ b/src/word_model_trainer.cc
@@ -14,6 +14,8 @@
 
 #include "word_model_trainer.h"
 
+#include <cmath>
+
 #include "stringpiece.h"
 #include "util.h"
 #include "word_model.h"


### PR DESCRIPTION
I tried to compile, but I encountered a compilation error. I guess `#include <cmath>` is missing.

```
/tmp/sentencepiece # make
make  all-recursive
make[1]: Entering directory '/tmp/sentencepiece'
Making all in src
make[2]: Entering directory '/tmp/sentencepiece/src'
make  all-am
make[3]: Entering directory '/tmp/sentencepiece/src'
g++ -DHAVE_CONFIG_H -I. -I..     -std=c++11 -Wall -O3   -MT word_model_trainer.o -MD -MP -MF .deps/word_model_trai
ner.Tpo -c -o word_model_trainer.o word_model_trainer.cc
word_model_trainer.cc: In member function 'virtual void sentencepiece::word::Trainer::Train()':
word_model_trainer.cc:60:31: error: 'log' was not declared in this scope
   const float logsum = log(sum);
```

I replicated the issue using alpine docker, not ubuntu.

```
FROM alpine

RUN apk add --no-cache git automake autoconf automake libtool g++ protobuf protobuf-dev make

RUN git clone --depth 1 https://github.com/google/sentencepiece.git /tmp/sentencepiece && \
      cd /tmp/sentencepiece && \
      ./autogen.sh && \
      ./configure && \
      make
```

Notice: I am C++ newbie.