### PR TITLE
Fix stack-overflow in StringPiece

### DIFF
--- a/src/stringpiece.h
+++ b/src/stringpiece.h
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <string>
+#include <ostream>
 
 namespace sentencepiece {
 
@@ -215,8 +216,7 @@ inline int StringPiece::compare(StringPiece b) const {
 }
 
 inline std::ostream &operator<<(std::ostream &o, StringPiece piece) {
-  o << piece.data();
-  return o;
+  return o.write(piece.data(), static_cast<std::streamsize>(piece.size()));
 }
 
 struct StringPieceHash {


### PR DESCRIPTION
The compiler complains that StringPiece::operator<< leads to stack
overflows due to the infinite recursion (-Winfinite-recursion).

Running the following sample program causes a stack overflow

```
$ cat stringpiece_test.cc
#include "stringpiece.h"
#include <iostream>

int main() {
  std::string s("zuzuzu...");
  sentencepiece::StringPiece sp(s.data(), s.size());
  std::cout << sp << std::endl;
  return 0;
}
$ clang++ -fsanitize=address stringpiece_test.cc
$ ./a.out
ASAN:DEADLYSIGNAL
=================================================================
==76454==ERROR: AddressSanitizer: stack-overflow on address 0x7fff59be3fa8 (pc 0x000105869745 bp 0x7fff59be4810 sp 0x7fff59be3fb0 T0)
    #0 0x105869744 in wrap_strlen (libclang_rt.asan_osx_dynamic.dylib+0x45744)
    #1 0x10581db81 in sentencepiece::StringPiece::StringPiece(char const*) (a.out+0x100001b81)
    #2 0x10581db0c in sentencepiece::StringPiece::StringPiece(char const*) (a.out+0x100001b0c)
    #3 0x10581d5cb in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x1000015cb)
    #4 0x10581d646 in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x100001646)
    #5 0x10581d646 in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x100001646)
    #6 0x10581d646 in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x100001646)
...
    #254 0x10581d646 in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x100001646)
    #255 0x10581d646 in sentencepiece::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, sentencepiece::StringPiece) (a.out+0x100001646)

SUMMARY: AddressSanitizer: stack-overflow (libclang_rt.asan_osx_dynamic.dylib+0x45744) in wrap_strlen
==76454==ABORTING
```

OS: Mac OS X 10.12.3
clang: Apple LLVM version 8.0.0 (clang-800.0.42.1)