### PR TITLE
Add support to use self-prepared protobuf lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ On OSX, you can use brew:
 ```
 % brew install protobuf autoconf automake libtool
 ```
+Use your prepared protobuf library:
+```
+Setup below environment variables before build
+% export PROTOBUF=<path_to_protobuf>
+% export PROTOC="$PROTOBUF/bin/protoc"
+% export PROTOBUF_LIBS="-L$PROTOBUF/lib -lprotobuf -D_THREAD_SAFE"
+% export PROTOBUF_CFLAGS="-I$PROTOBUF/include -D_THREAD_SAFE" 
+```
 
 ## Build and Install SentencePiece
 ```

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ On OSX, you can use brew:
 ```
 % brew install protobuf autoconf automake libtool
 ```
-Use your prepared protobuf library:
+
+If want to use self-prepared protobuf library, setup below environment variables before build:
 ```
-Setup below environment variables before build
 % export PROTOBUF=<path_to_protobuf>
 % export PROTOC="$PROTOBUF/bin/protoc"
 % export PROTOBUF_LIBS="-L$PROTOBUF/lib -lprotobuf -D_THREAD_SAFE"

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,9 @@ LIBS="$LIBS $PROTOBUF_LIBS"
 
 m4_include([third_party/m4/ax_check_icu.m4])
 
-AC_CHECK_PROG([PROTOC], [protoc], [protoc])
+if test ! -n "$PROTOC"; then
+  AC_CHECK_PROG([PROTOC], [protoc], [protoc])
+fi
 AS_IF([test "x${PROTOC}" == "x"],
     [AC_MSG_ERROR([ProtoBuf compiler "protoc" not found. You can install them with "sudo apt-get install libprotobuf-c++ protobuf-compiler" ])])
 


### PR DESCRIPTION
I am trying to build sentencepiece on iOS along with tensorflow. And I want to build sentencepiece using tensorflow's costumed protobuf. By adding a env-var checking to configure.ac, It worked. I also add some guide line to README.md on how to use self-prepared protobuf lib.