### PR TITLE
spm_encode should not ignore empty lines

### DIFF
--- a/src/spm_encode_main.cc
+++ b/src/spm_encode_main.cc
@@ -69,6 +69,7 @@ int main(int argc, char *argv[]) {
     sentencepiece::io::InputBuffer input(filename);
     while (input.ReadLine(&line)) {
       if (line.empty()) {
+	output.WriteLine("");
         continue;
       }
       process(line);


### PR DESCRIPTION
The current version of spm_encode ignores empty lines, thus the line number of its input file does not match the line number of its output file.   The filter program such as spm_encode should do its most simple work only.  If its user wants to remove empty lines, he/she can do it with `grep' command as you know.
