### PR TITLE
std::istream interface for SentencepieceProcessor construction

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -4,7 +4,7 @@
 To start working with the SentencePiece model, you will want to include the `sentencepiece_processor.h` header file.
 Then instantiate sentencepiece::SentencePieceProcessor class and calls `Load`or `LoadOrDie` method to load the model with file path or std::istream.
 
-```
+```C++
 #include <sentencepiece_processor.h>
 
 sentencepiece::SentencePieceProcessor processor;
@@ -17,7 +17,7 @@ processor.LoadOrDie("//path/to/model.model");
 ## Tokenize text (preprocessing)
 Calls `SentencePieceProcessor::Encode` method to tokenize text.
 
-```
+```C++
 std::vector<std::string> pieces;
 processor.Encode("This is a test.", &pieces);
 for (const std::string &token : pieces) {
@@ -27,7 +27,7 @@ for (const std::string &token : pieces) {
 
 You will obtain the sequence of vocab ids as follows:
 
-```
+```C++
 std::vector<int> ids;
 processor.Encode("This is a test.", &ids);
 for (const int id : ids) {
@@ -38,7 +38,7 @@ for (const int id : ids) {
 ## Detokenize text (postprocessing)
 Calls `SentencePieceProcessor::Decode` method to detokenize a sequence of pieces or ids into a text. Basically it is guaranteed that the detoknization is an inverse operation of Encode, i.e., `Decode(Encode(Normalize(input))) == Normalize(input)`.
 
-```
+```C++
 std::vector<std::string> pieces = { "▁This", "▁is", "▁a", "▁", "te", "st", "." };   // sequence of pieces
 std::string text
 processor.Decode(pieces, &text);
@@ -52,7 +52,7 @@ std::cout << text << std::endl;
 ## SentencePieceText proto
 You will want to use `SentencePieceText` class to obtain the pieces and ids at the same time. This proto also encodes a utf8-byte offset of each piece over user input or detokenized text.
 
-```
+```C++
 #include <sentencepiece.pb.h>
 
 sentencepiece::SentencePieceText spt;
@@ -80,7 +80,7 @@ for (const auto &piece : spt.pieces()) {
 ## Vocabulary management
 You will want to use the following methods to obtain ids from/to pieces.
 
-```
+```C++
 processor.GetPieceSize();   // returns the size of vocabs.
 processor.PieceToId("foo");  // returns the vocab id of "foo"
 processor.IdToPiece(10);     // returns the string representation of id 10.
@@ -91,7 +91,7 @@ processor.IsControl(10);     // returns true if the given id is a control token.
 ## Extra Options
 Use `SetEncodeExtraOptions` and `SetDecodeExtraOptions` methods to set extra options for encoding and decoding respectively. These methods need to be called just after `Load/LoadOrDie` methods.
 
-```
+```C++
 processor.SetEncodeExtraOptions("bos:eos");   // add <s> and </s>.
 processor.SetEncodeExtraOptions("reverse:bos:eos");   // reverse the input and then add <s> and </s>.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -2,13 +2,16 @@
 
 ## Load SentencePiece model
 To start working with the SentencePiece model, you will want to include the `sentencepiece_processor.h` header file.
-Then instantiate sentencepiece::SentencePieceProcessor class and calls `Load`or `LoadOrDie` method to load the model file.
+Then instantiate sentencepiece::SentencePieceProcessor class and calls `Load`or `LoadOrDie` method to load the model with file path or std::istream.
 
 ```
 #include <sentencepiece_processor.h>
 
 sentencepiece::SentencePieceProcessor processor;
 processor.LoadOrDie("//path/to/model.model");
+// Or load from std::istream of anything
+// std::ifstream in("//path/to/model.model");
+// processor.LoadOrDie(in);
 ```
 
 ## Tokenize text (preprocessing)

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -42,12 +42,14 @@ bool SentencePieceProcessor::Load(const std::string &filename) {
     return false;
   }
 
-  return Load(ifs);
+  return Load(&ifs);
 }
 
-bool SentencePieceProcessor::Load(std::istream &istream) {
+bool SentencePieceProcessor::Load(std::istream *is) {
+  CHECK_NOTNULL(is);
+  
   model_proto_ = port::MakeUnique<ModelProto>();
-  if (!model_proto_->ParseFromIstream(&istream)) {
+  if (!model_proto_->ParseFromIstream(is)) {
     LOG(WARNING) << "Model file is broken";
     return false;
   }
@@ -63,8 +65,8 @@ void SentencePieceProcessor::LoadOrDie(const std::string &filename) {
   CHECK(Load(filename)) << "failed to load model: " << filename;
 }
 
-void SentencePieceProcessor::LoadOrDie(std::istream &istream) {
-  CHECK(Load(istream)) << "failed to load model";
+void SentencePieceProcessor::LoadOrDie(std::istream *is) {
+  CHECK(Load(is)) << "failed to load model";
 }
 
 void SentencePieceProcessor::SetEncodeExtraOptions(

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -42,9 +42,13 @@ bool SentencePieceProcessor::Load(const std::string &filename) {
     return false;
   }
 
+  return Load(ifs);
+}
+
+bool SentencePieceProcessor::Load(std::istream &istream) {
   model_proto_ = port::MakeUnique<ModelProto>();
-  if (!model_proto_->ParseFromIstream(&ifs)) {
-    LOG(WARNING) << "Model file is broken: " << filename;
+  if (!model_proto_->ParseFromIstream(&istream)) {
+    LOG(WARNING) << "Model file is broken";
     return false;
   }
 
@@ -57,6 +61,10 @@ bool SentencePieceProcessor::Load(const std::string &filename) {
 
 void SentencePieceProcessor::LoadOrDie(const std::string &filename) {
   CHECK(Load(filename)) << "failed to load model: " << filename;
+}
+
+void SentencePieceProcessor::LoadOrDie(std::istream &istream) {
+  CHECK(Load(istream)) << "failed to load model";
 }
 
 void SentencePieceProcessor::SetEncodeExtraOptions(

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -92,9 +92,17 @@ class SentencePieceProcessor {
   // Returns false if |filename| cannot be loaded.
   virtual bool Load(const std::string &filename);
 
+  // Loads model from |istream|.
+  // Returns false if |istream| cannot be loaded.
+  virtual bool Load(std::istream &istream);
+
   // Loads model from |filename|.
   // Dies if |filename| cannot be loaded.
   virtual void LoadOrDie(const std::string &filename);
+
+  // Loads model from |istream|.
+  // Dies if |istream| cannot be loaded.
+  virtual void LoadOrDie(std::istream &istream);
 
   // Sets encode extra_option sequence.
   virtual void SetEncodeExtraOptions(const std::string &extra_option);

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -92,17 +92,17 @@ class SentencePieceProcessor {
   // Returns false if |filename| cannot be loaded.
   virtual bool Load(const std::string &filename);
 
-  // Loads model from |istream|.
-  // Returns false if |istream| cannot be loaded.
-  virtual bool Load(std::istream &istream);
+  // Loads model from |is|.
+  // Returns false if |is| cannot be loaded.
+  virtual bool Load(std::istream *is);
 
   // Loads model from |filename|.
   // Dies if |filename| cannot be loaded.
   virtual void LoadOrDie(const std::string &filename);
 
-  // Loads model from |istream|.
-  // Dies if |istream| cannot be loaded.
-  virtual void LoadOrDie(std::istream &istream);
+  // Loads model from |is|.
+  // Dies if |is| cannot be loaded.
+  virtual void LoadOrDie(std::istream *is);
 
   // Sets encode extra_option sequence.
   virtual void SetEncodeExtraOptions(const std::string &extra_option);

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -372,7 +372,7 @@ TEST(SentencePieceProcessorTest, LoadInvalidModelTest) {
   EXPECT_DEATH(sp.LoadOrDie(""));
   EXPECT_DEATH(sp.LoadOrDie("__UNKNOWN_FILE__"));
   std::istringstream ss("__UNKNOWN_STREAM__");
-  EXPECT_DEATH(sp.LoadOrDie(ss));
+  EXPECT_DEATH(sp.LoadOrDie(&ss));
 }
 
 TEST(SentencePieceProcessorTest, EndToEndTest) {

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -14,6 +14,7 @@
 
 #include "sentencepiece_processor.h"
 #include <unordered_map>
+#include <sstream>
 #include "builder.h"
 #include "model_interface.h"
 #include "normalizer.h"
@@ -371,6 +372,8 @@ TEST(SentencePieceProcessorTest, LoadInvalidModelTest) {
   SentencePieceProcessor sp;
   EXPECT_DEATH(sp.LoadOrDie(""));
   EXPECT_DEATH(sp.LoadOrDie("__UNKNOWN_FILE__"));
+  std::istringstream ss("__UNKNOWN_STREAM__");
+  EXPECT_DEATH(sp.LoadOrDie(ss));
 }
 
 TEST(SentencePieceProcessorTest, EndToEndTest) {

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -14,7 +14,6 @@
 
 #include "sentencepiece_processor.h"
 #include <unordered_map>
-#include <sstream>
 #include "builder.h"
 #include "model_interface.h"
 #include "normalizer.h"


### PR DESCRIPTION
Added two construction interface for SentencepieceProcessor, using std::istream to initialize the model.
These interfaces are very useful in case when we construct the model from Android assets or Network where we can only have the input stream of the model file.