### PR TITLE
SWIG wrapper to simple sentencepiece model

### DIFF
--- a/makefile.swig
+++ b/makefile.swig
@@ -1,0 +1,19 @@
+py_ver = 3.4
+
+all: _spm.so
+
+spm_wrap.cxx: spm.i
+	swig $(SWIGFLAGS) -python -py3 -c++ spm.i
+
+spm_wrap.o: spm_wrap.cxx
+	g++ -I. -Isrc -I/usr/include/python$(py_ver) -std=c++11 -Wall -O3 -c spm_wrap.cxx -DPIC -fPIC
+
+_spm.so: spm_wrap.o
+	g++ -shared spm_wrap.o -o _spm.so -fPIC -Lsrc/.libs -lsentencepiece -lprotobuf 
+
+install: _spm.so
+	@cp -f _spm.so $(HOME)/lib/python$(py_ver)/site-packages/
+	@cp -f spm.py $(HOME)/lib/python$(py_ver)/site-packages/
+
+clean:
+	rm -f *.o _*.so *.pyc spm.py *_wrap.* *~

--- a/spm.i
+++ b/spm.i
@@ -1,0 +1,7 @@
+%module spm
+%{
+#include "src/spm_model.h"
+%}
+
+%include <std_string.i>
+%include "src/spm_model.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,8 +39,11 @@ BUILT_SOURCES = \
 
 EXTRA_DIST = sentencepiece.proto sentencepiece_model.proto	
 
-bin_PROGRAMS = spm_encode spm_decode spm_normalize spm_train spm_export_vocab
+bin_PROGRAMS = spm_model spm_encode spm_decode spm_normalize spm_train spm_export_vocab
 noinst_PROGRAMS = compile_charsmap
+
+spm_model_SOURCES = spm_model.cc
+spm_model_LDADD = libsentencepiece.la
 
 spm_encode_SOURCES = spm_encode_main.cc
 spm_encode_LDADD = libsentencepiece.la

--- a/src/spm_model.cc
+++ b/src/spm_model.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+#include "spm_model.h"
+
+int main(int argc, char *argv[]) {
+  std::string filename(argv[1]);
+  SentencePieceModel* spm = new SentencePieceModel(filename);
+  std::string encoded = spm->encode("this is a test");
+  std::cout << encoded << std::endl;
+  std::cout << spm->decode(encoded) << std::endl;
+  return 0;
+}

--- a/src/spm_model.h
+++ b/src/spm_model.h
@@ -1,0 +1,28 @@
+#include <string>
+#include "util.h"
+#include "sentencepiece_processor.h"
+
+class SentencePieceModel {
+  sentencepiece::SentencePieceProcessor sp;
+public:
+  SentencePieceModel(std::string filename);
+  std::string encode(std::string line);
+  std::string decode(std::string line);
+};
+
+SentencePieceModel::SentencePieceModel(std::string filename) {
+  sp.LoadOrDie(filename);
+}
+
+std::string SentencePieceModel::encode(std::string line) {
+  std::vector<std::string> sps;
+  sp.Encode(line, &sps);
+  return sentencepiece::string_util::Join(sps, " ");  
+}
+
+std::string SentencePieceModel::decode(std::string line) {
+  std::vector<std::string> sps = sentencepiece::string_util::Split(line, " ");
+  std::string detok;
+  sp.Decode(sps, &detok);
+  return detok;
+}


### PR DESCRIPTION
- make sentencepiece (follow README)
- make Python module:
  make -f makefile.swig
  (patch the Python version in the makefile if not 3.4)
- install _spm.so and spm.py to your PYTHONPATH

Usage:
```
>>> import spm
>>> m = spm.SentencePieceModel("test.model")
>>> print m.encode("this is a test")
▁this ▁is ▁a ▁test
>>> print m.decode(m.encode("this is a test"))
this is a test
```