### PR TITLE
Fix typos in python/README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,14 +1,14 @@
 # SentencePiece Python Wrapper
 
 Python wrapper for SentencePiece with SWIG. This module wraps sentencepiece::SentencePieceProcessor class with the following modifications:
-* Encode and Decode methods are re-defined as EncodeAsIds, EncodeAsPieces, DecodeIds and DecodePieces respectevely.
+* Encode and Decode methods are re-defined as EncodeAsIds, EncodeAsPieces, DecodeIds and DecodePieces respectively.
 * SentencePieceText proto is not supported.
 * Added __len__ and __getitem__ methods. len(obj) and obj[key] returns vocab size and vocab id respectively.
 
 ## Build and Install SentencePiece
 You need to install SentencePiece before installing this python wrapper.
 
-You can simply use pip comand to install SentencePiece python module.
+You can simply use pip command to install SentencePiece python module.
 
 ```
 % pip install sentencepiece


### PR DESCRIPTION
This PR fixes typos in `python/README.md`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/sentencepiece/22)
<!-- Reviewable:end -->
