### PR TITLE
Fix an incompatibility problem on setup.py for Python 3.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,8 @@ with open("README.md") as f:
 def cmd(line):
     try:
         output = subprocess.check_output(line, shell=True)
+        if sys.version_info >= (3,0,0):
+            output = output.decode('utf-8')
     except subprocess.CalledProcessError:
         sys.stderr.write('Failed to find sentencepiece pkgconfig\n')
         sys.exit(1)


### PR DESCRIPTION
Fixed a build error by Python 3.
subprocess.check_output returns 'bytes' not 'str' in Python 3.