### PR TITLE
Fix inconsistent default vocab size

### DIFF
--- a/src/sentencepiece_model.proto
+++ b/src/sentencepiece_model.proto
@@ -44,7 +44,7 @@ message TrainerSpec {
   }
   optional ModelType model_type = 3 [ default = UNIGRAM ];
 
-  // Vocabulary size. 32k is the default size.
+  // Vocabulary size. 8k is the default size.
   optional int32  vocab_size = 4 [ default = 8000 ];
 
   // List of the languages this model can accept.


### PR DESCRIPTION
There is a discrepancy between actual default value `vocab_size` (8000) and its comment (32k). 
This should be fixed. I'm not sure which one is preferred, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/sentencepiece/48)
<!-- Reviewable:end -->
