### PR TITLE
Fix typo in examples of control symbols

### DIFF
--- a/src/sentencepiece.proto
+++ b/src/sentencepiece.proto
@@ -37,7 +37,7 @@ message SentencePieceText {
     // - Concatenation of surface is always the same as the |text|.
     // - |surface| may contain whitespaces.
     // - |surface| may be empty if the piece encodes
-    //   a control vocabulary. e.g., </s>, </s>, <unk>.
+    //   a control vocabulary. e.g., <s>, </s>, <unk>.
     // - When |surface| is empty, always begin == end. (zero-length span).
     optional string surface = 3;
 


### PR DESCRIPTION
There is a duplication in comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/sentencepiece/49)
<!-- Reviewable:end -->
