### PR TITLE
Updating install instructions for OSX/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ If want to use self-prepared protobuf library, setup below environment variables
 % sudo make install
 $ sudo ldconfig -v
 ```
+On OSX/macOS, replace the last command with: 
+```$ sudo update_dyld_shared_cache```
+
 ## Usage instructions
 ### Train SentencePiece Model
 ```

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If want to use self-prepared protobuf library, setup below environment variables
 % sudo make install
 $ sudo ldconfig -v
 ```
-On OSX/macOS, replace the last command with: 
+On OSX/macOS, replace the last command with the following: 
 ```$ sudo update_dyld_shared_cache```
 
 ## Usage instructions


### PR DESCRIPTION
ldconfig is a linux command; update_dyld_shared_cache seems to work (courtesy of https://stackoverflow.com/a/45920815, verified on my computer).