### PR TITLE
invalid test causing all pieces to be identified as non valid 

### DIFF
--- a/src/trainer_interface.cc
+++ b/src/trainer_interface.cc
@@ -123,7 +123,7 @@ bool TrainerInterface::IsValidSentencePiece(
       }
       // Do not allow a piece to include multiple Unicode scripts
       // when split_by_unicode_script() is true (default = true).
-      if (prev_script != -1 && prev_script != s &&
+      if (prev_script != static_cast<unicode_script::ScriptType>(-1) && prev_script != s &&
           trainer_spec_.split_by_unicode_script()) {
         return false;
       }


### PR DESCRIPTION
when split_by_unicode_script() is true 

using clang 9.1:
```
warning: comparison of constant -1 with expression of type 'unicode_script::ScriptType' is always true [-Wtautological-constant-out-of-range-compare]
```
