### PR TITLE
change notebook link to avoid permission errors

### DIFF
--- a/tensorflow/README.md
+++ b/tensorflow/README.md
@@ -17,4 +17,4 @@ Use pydoc to see the usage instruction
 % pydoc sentencepiece_processor_ops
 ```
 
-[Sample code](https://colab.research.google.com/drive/1rQ0tgXmHv02sMO6VdTO0yYaTvc1Yv1yP?authuser=2#scrollTo=i_44FzFC0qwe)
+[Sample code](https://colab.research.google.com/drive/1rQ0tgXmHv02sMO6VdTO0yYaTvc1Yv1yP)


### PR DESCRIPTION
notebook link gives "Invalid Credentials" error if only one account is logged in. Works fine in incognito.