### PR TITLE
Fix version extraction from library files

### DIFF
--- a/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
+++ b/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
@@ -35,7 +35,7 @@ if not hasattr(tf, 'no_gradient'):
 
 if not os.path.exists(so_file):
   versions = [
-      re.search('[0-9]+\.[0-9\.]+.*$', n).group(0)
+      re.search('[0-9]+\.[0-9\.]+.*$', os.path.basename(n)).group(0)
       for n in glob.glob(so_base + '.*')
   ]
   latest = sorted(versions, key=LooseVersion)[-1]


### PR DESCRIPTION
tensorflow==1.15.0

As a library file does not exists for tensorflow version 1.15.0, this command is invoked. However, the regex fails to extract the correct versions, if there are other version numbers in the full path of the library files.

**Example:**
The following path:
`"/home/<user>/<project>/.venv/lib/python3.7/site-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.2.0.0"`

Gets parsed by the regex as:
`"3.7/site-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.2.0.0"`

And so:
`so_file = "/home/<user>/<project>/.venv/lib/python3.7/site-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.3.7/site-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.2.0.0"`

Which results in:
`tensorflow.python.framework.errors_impl.NotFoundError: <path>: cannot open shared object file: No such file or directory`


The fix applies the regex only on the basename of the library file path.