### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ To enable subword regularization, you would like to integrate SentencePiece libr
 
 ## Installation
 
+### Building sentencepiece - Using vcpkg
+
+You can download and install sentencepiece using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install sentencepiece
+
+The sentencepiece port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Python module
 SentencePiece provides Python wrapper that supports both SentencePiece training and segmentation.
 You can install Python binary package of SentencePiece with.


### PR DESCRIPTION
Sentencepiece is available as a port in vcpkg, a C++ library manager that simplifies installation for sentencepiece and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build sentencepiece, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.