### PR TITLE
Fix library selection logic

### DIFF
--- a/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
+++ b/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
@@ -35,7 +35,7 @@ if not hasattr(tf, 'no_gradient'):
 
 if not os.path.exists(so_file):
   versions = [
-      re.search('so.([0-9]+\.[0-9\.]+.*)$', os.path.basename(n)).group(0)
+      re.search('so.([0-9]+\.[0-9\.]+.*)$', os.path.basename(n)).group(1)
       for n in glob.glob(so_base + '.*')
   ]
   latest = sorted(versions, key=LooseVersion)[-1]


### PR DESCRIPTION
In the branch which is executed if no exact match is found,
extract the captured version number from the regex instead
of the complete match.

See issue #456 .