### PR TITLE
Fix version detection bug

### DIFF
--- a/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
+++ b/tensorflow/tf_sentencepiece/sentencepiece_processor_ops.py
@@ -35,7 +35,7 @@ if not hasattr(tf, 'no_gradient'):
 
 if not os.path.exists(so_file):
   versions = [
-      re.search('so.([0-9]+\.[0-9\.]+.*)$', os.path.basename(n)).group(0)
+      re.search('so.([0-9]+\.[0-9\.]+.*)$', os.path.basename(n)).group(1)
       for n in glob.glob(so_base + '.*')
   ]
   latest = sorted(versions, key=LooseVersion)[-1]


### PR DESCRIPTION
Currently, the code return paths with double extensions '.so' such as 
'/usr/local/lib/python3.6/dist-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.so.2.0.0'

This is result from return group 0 instead of 1 in version detection codebase, switching to group 1 fixes the issue to
'/usr/local/lib/python3.6/dist-packages/tf_sentencepiece/_sentencepiece_processor_ops.so.2.0.0'