### PR TITLE
clear description for alpha of BPE-dropout

### DIFF
--- a/python/sentencepiece.i
+++ b/python/sentencepiece.i
@@ -223,8 +223,8 @@ class PySentenceIterator : public sentencepiece::SentenceIterator {
                   nbest_size < 0: assuming that nbest_size is infinite and samples
                     from the all hypothesis (lattice) using
                     forward-filtering-and-backward-sampling algorithm.
-      alpha: Soothing parameter for unigram sampling, and merge probability for
-        BPE-dropout.
+      alpha: Soothing parameter for unigram sampling, and dropout probability of
+        merge operations for BPE-dropout.
     """
 
     _sentencepiece_processor_init_native(self)

--- a/python/sentencepiece.py
+++ b/python/sentencepiece.py
@@ -202,8 +202,8 @@ class SentencePieceProcessor(object):
                     nbest_size < 0: assuming that nbest_size is infinite and samples
                       from the all hypothesis (lattice) using
                       forward-filtering-and-backward-sampling algorithm.
-        alpha: Soothing parameter for unigram sampling, and merge probability for
-          BPE-dropout.
+        alpha: Soothing parameter for unigram sampling, and dropout probability of
+          merge operations for BPE-dropout.
       """
 
       _sentencepiece_processor_init_native(self)
@@ -242,8 +242,8 @@ class SentencePieceProcessor(object):
                     nbest_size < 0: assuming that nbest_size is infinite and samples
                       from the all hypothesis (lattice) using
                       forward-filtering-and-backward-sampling algorithm.
-        alpha: Soothing parameter for unigram sampling, and merge probability for
-          BPE-dropout.
+        alpha: Soothing parameter for unigram sampling, and dropout probability of
+          merge operations for BPE-dropout.
       """
 
       if out_type is None:

--- a/src/bpe_model.h
+++ b/src/bpe_model.h
@@ -37,7 +37,7 @@ class Model : public ModelInterface {
   }
 
   // Sampling with BPE-dropout: https://arxiv.org/pdf/1910.13267.pdf
-  // `alpha` is merge probability in BPE-dropout paper.
+  // `alpha` is dropout probability in BPE-dropout paper.
   // Skips merge operation with `alpha` probability.
   // When alpha <= 0.0, no sampling is performed.
   EncodeResult SampleEncode(absl::string_view normalized,

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -285,7 +285,8 @@ class SentencePieceProcessor {
   // in https://arxiv.org/abs/1804.10959  (nbest_size < 0 means l = infinity)
   //
   // - BPE (--model_type=bpe):
-  // `alpha` is the merge probability `p` in https://arxiv.org/abs/1910.13267
+  // `alpha` is the dropout probability `p` of bpe merge operations
+  // in https://arxiv.org/abs/1910.13267
   // Nbest-based sampling is not supported so nbest_size parameter is ignored in
   // BPE.
   virtual util::Status SampleEncode(absl::string_view input, int nbest_size,


### PR DESCRIPTION
Previous descriptions of alpha regarding BPE dropout are misleading.
By saying alpha to be the merge probability in BPE-dropout will make us thinking `dropout = 1 - alpha`, but it is not.
This PR fixes the descriptions across the code comments to clarify this potential misunderstanding.