### PR TITLE
Fix space symbol in code snippet: _ -> ▁

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then, this text is segmented into small pieces, for example:
 Since the whitespace is preserved in the segmented text, we can detokenize the text without any ambiguities.
 
 ```
-  detokenized = ''.join(pieces).replace('_', ' ')
+  detokenized = ''.join(pieces).replace('▁', ' ')
 ```
 
 This feature makes it possible to perform detokenization without relying on language-specific resources.


### PR DESCRIPTION
The original code snipped contains underscore "_" symbol, but it should be "▁" (U+2581) instead.
This commit only fixes this typo.