### PR TITLE
fix bpe dropout with alpha == 0 (now yields deterministic BPE)

### DIFF
--- a/python/sentencepiece.i
+++ b/python/sentencepiece.i
@@ -263,7 +263,7 @@ class PySentenceIterator : public sentencepiece::SentenceIterator {
                   nbest_size < 0: assuming that nbest_size is infinite and samples
                     from the all hypothesis (lattice) using
                     forward-filtering-and-backward-sampling algorithm.
-      alpha: Soothing parameter for unigram sampling, and merge probability for
+      alpha: Soothing parameter for unigram sampling, and dropout probability for
         BPE-dropout.
     """
 
@@ -284,10 +284,10 @@ class PySentenceIterator : public sentencepiece::SentenceIterator {
 
     if enable_sampling == True and (nbest_size is None or nbest_size == 0 or
                                         nbest_size == 1 or alpha is None or
-                                        alpha <= 0.0 or alpha > 1.0):
+                                        alpha < 0.0 or alpha > 1.0):
       raise RuntimeError(
           'When enable_sampling is True, We must specify "nbest_size > 1" or "nbest_size = -1", '
-          'and "0.0 < alpha < 1.0". "nbest_size = -1" is enabled only on unigram mode and '
+          'and "0.0 <= alpha <= 1.0". "nbest_size = -1" is enabled only on unigram mode and '
           'samples from all candidates on the lattice instead of nbest segmentations. '
       )
 

--- a/python/sentencepiece.py
+++ b/python/sentencepiece.py
@@ -263,10 +263,10 @@ class SentencePieceProcessor(object):
 
       if enable_sampling == True and (nbest_size is None or nbest_size == 0 or
                                           nbest_size == 1 or alpha is None or
-                                          alpha <= 0.0 or alpha > 1.0):
+                                          alpha < 0.0 or alpha > 1.0):
         raise RuntimeError(
             'When enable_sampling is True, We must specify "nbest_size > 1" or "nbest_size = -1", '
-            'and "0.0 < alpha < 1.0". "nbest_size = -1" is enabled only on unigram mode and '
+            'and "0.0 <= alpha <= 1.0". "nbest_size = -1" is enabled only on unigram mode and '
             'samples from all candidates on the lattice instead of nbest segmentations. '
         )
 


### PR DESCRIPTION
Minimally Fixes #569 

Error conditions and messages can be further improved by being model type specific (i.e. alpha has different requirements for LM vs BPE mode).