### PR TITLE
fix appveyor python 3.9 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{branch} build {build}'
-image: Visual Studio 2015
+image: Visual Studio 2019
 platform:
   - x64
   - Win32


### PR DESCRIPTION
Updating the appveyor visual studio version seems to remove cpython 3.5 support and add cpython 3.9 support. Seems like you'll need to use two appveyor builds if you want to cover cpython 3.5 still.