### PR TITLE
Add missing #include for BYTE_ORDER

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -36,8 +36,11 @@
 #include <pthread.h>
 #endif
 
-#if !defined(__APPLE__) && !defined(_WIN32) && BYTE_ORDER == __BIG_ENDIAN
+#if !defined(__APPLE__) && !defined(_WIN32)
+#include <endian.h>
+#if defined(BYTE_ORDER) && defined(__BIG_ENDIAN) && BYTE_ORDER == __BIG_ENDIAN
 #define IS_BIG_ENDIAN
+#endif
 #endif
 
 namespace sentencepiece {


### PR DESCRIPTION
util.h didn't include the necessary header file before using the `BYTE_ORDER` and `__BIG_ENDIAN` macros. On standard Linux I guess it's included indirectly, but on Android it isn't.

All undefined preprocessor macros implicitly have the value 0. So `BYTE_ORDER == __BIG_ENDIAN` became `0 == 0`, which is always true, and all Android platforms were treated as big-endian. The build still succeeded, but reading a model file crashed at runtime with the error "Trie data size exceeds the input blob size".