### PR TITLE
Restore the sentence boundary marker insertion for the unigram model trainer

### DIFF
--- a/src/unigram_model_trainer.cc
+++ b/src/unigram_model_trainer.cc
@@ -119,6 +119,7 @@ TrainerModel::SentencePieces Trainer::MakeSeedSentencePieces() const {
         all_chars[string_util::UnicodeCharToUTF8(c)] += w.second;
       }
     }
+    array.push_back(kSentenceBoundary);  // sentence boundary marker.
   }
 
   CHECK_LE(array.size(),


### PR DESCRIPTION
This pull request suggests restoring the sentence boundary insertion code for the suffix array creation in the unigram model trainer, in order to significantly re-speedup training.

This appears to have been deleted here:
- https://github.com/google/sentencepiece/commit/329383b455a5795f3d182159eb0985a3f20f0fa2#diff-51c497698d155a53cbd00dfd1a26018599599affa606d6fd44d663d18d4535aaL116 

during the commit that 'merged the internal sentencepiece'. 

I believe this also relates to the following issues:
- https://github.com/google/sentencepiece/issues/641
- https://github.com/google/sentencepiece/issues/615

I'm not sure if there is a qualitative/modeling reason behind this change (or if there is a settings way to avoid this?), but the difference in training speed with and without this line, for anything larger than very small corpora where the unigram model is concerned is very dramatic.  I'm also not 100% certain that there are not knock-on effects from this change, due to the large number of additional changes in the original commit that removed this line; but so far I do not notice any noticeable difference in downstream accuracy from this restoration.

On the speed point, I downloaded the [librispeech-lm-norm.txt.gz](https://www.openslr.org/resources/11/librispeech-lm-norm.txt.gz) corpus, and extracted the first 500k sentences, after this change, it takes approximately 1min on my MacBook Pro, running in an Ubuntu 20.04 VM via virtualbox to run the following training:
- `spm_train --input=ls-500k.txt --model_prefix=m --vocab_size=2000`

I gave up waiting for it to finish without the above change.

Your thoughts/suggestions on this would be appreciated.

edit: as #615 mentions, the associated comment implies that the boundary is still supposed to be there:
https://github.com/google/sentencepiece/blob/bc53923a9147dc8ffa54034c8ed774de78cc4d39/src/unigram_model_trainer.cc#L108