### PR TITLE
Expose CalculateEntropy and SampleEncodeAndScore methods to python

### DIFF
--- a/python/src/sentencepiece/__init__.py
+++ b/python/src/sentencepiece/__init__.py
@@ -113,6 +113,12 @@ class SentencePieceProcessor(object):
     def SampleEncodeAsIds(self, input, nbest_size, alpha):
         return _sentencepiece.SentencePieceProcessor_SampleEncodeAsIds(self, input, nbest_size, alpha)
 
+    def SampleEncodeAndScoreAsPieces(self, input, samples, theta, wor, include_best):
+        return _sentencepiece.SentencePieceProcessor_SampleEncodeAndScoreAsPieces(self, input, samples, theta, wor, include_best)
+
+    def SampleEncodeAndScoreAsIds(self, input, samples, theta, wor, include_best):
+        return _sentencepiece.SentencePieceProcessor_SampleEncodeAndScoreAsIds(self, input, samples, theta, wor, include_best)
+
     def DecodePieces(self, pieces):
         return _sentencepiece.SentencePieceProcessor_DecodePieces(self, pieces)
 
@@ -175,6 +181,9 @@ class SentencePieceProcessor(object):
 
     def DecodeIdsAsSerializedProtoWithCheck(self, ids):
         return _sentencepiece.SentencePieceProcessor_DecodeIdsAsSerializedProtoWithCheck(self, ids)
+
+    def EntropyWrapper(self, input, theta):
+        return _sentencepiece.SentencePieceProcessor_EntropyWrapper(self, input, theta)
 
     def Init(self,
              model_file=None,
@@ -302,6 +311,102 @@ class SentencePieceProcessor(object):
         return [_encode(n) for n in input]
 
       return _encode(input)
+
+
+    def EncodeAndScore(self,
+                       input,
+                       out_type=None,
+                       add_bos=None,
+                       add_eos=None,
+                       reverse=None,
+                       samples=None,
+                       theta=None,
+                       wor=None,
+                       include_best=None):
+      """Encode text input to segmented ids or tokens.
+
+        Args:
+        input: input string. accepsts list of string.
+        out_type: output type. int or str.
+        add_bos: Add <s> to the result (Default = false)
+        add_eos: Add </s> to the result (Default = false) <s>/</s> is added after
+          reversing (if enabled).
+        reverse: Reverses the tokenized sequence (Default = false)
+        samples: How many samples to return (Default = 1)
+        theta: inverse temperature for sampling
+        wor: whether to sample without replacement (Default = false)
+        include_best: whether to include the best tokenization, requires wor=True
+          (Default = false)
+      """
+
+      if out_type is None:
+        out_type = self._out_type
+      if add_bos is None:
+        add_bos = self._add_bos
+      if add_eos is None:
+        add_eos = self._add_eos
+      if reverse is None:
+        reverse = self._reverse
+      if samples is None:
+        samples = 1
+      if theta is None:
+        theta = 1.
+      if wor is None:
+        wor = False
+      if include_best is None:
+        include_best = False
+
+      if include_best and not wor:
+        raise RuntimeError(
+            'When include_best is True, We must specify "wor = True".'
+        )
+
+      def _encode(text):
+        if out_type is int:
+          result = self.SampleEncodeAndScoreAsIds(text, samples, theta, wor, include_best)
+        else:
+          result = self.SampleEncodeAndScoreAsPieces(text, samples, theta, wor, include_best)
+
+        if reverse:
+          for r, _ in result:
+            r.reverse()
+        if add_bos:
+          if out_type is int:
+            result = [([self.bos_id()] + r, s) for r, s in result]
+          else:
+            result = [([self.IdToPiece(self.bos_id())] + r, s) for r, s in result]
+
+        if add_eos:
+          if out_type is int:
+            result = [(r + [self.eos_id()], s) for r, s in result]
+          else:
+            result = [(r + [self.IdToPiece(self.eos_id())], s) for r, s in result]
+
+        return result
+
+      if type(input) is list:
+        return [_encode(n) for n in input]
+
+      return _encode(input)
+
+
+    def Entropy(self,
+                input,
+                theta=None):
+      """Calculate entropy of the input string
+
+        Args:
+        input: input string. accepsts list of string.
+        theta: inverse temperature for sampling
+      """
+
+      if theta is None:
+        theta = 1.
+
+      if type(input) is list:
+        return [self.EntropyWrapper(n, theta) for n in input]
+
+      return self.EntropyWrapper(input, theta)
 
 
     def Decode(self, input):

--- a/python/src/sentencepiece/sentencepiece_wrap.cxx
+++ b/python/src/sentencepiece/sentencepiece_wrap.cxx
@@ -3300,6 +3300,20 @@ SWIG_AsVal_float (PyObject * obj, float *val)
 }
 
 
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
   #define SWIG_From_double   PyFloat_FromDouble 
 
 
@@ -3336,6 +3350,11 @@ SWIGINTERN sentencepiece::util::bytes sentencepiece_SentencePieceProcessor_Decod
             sentencepiece::util::StatusCode::kOutOfRange,
             "piece id is out of range.");
     return self->DecodeIdsAsSerializedProto(ids);
+  }
+SWIGINTERN float sentencepiece_SentencePieceProcessor_EntropyWrapper(sentencepiece::SentencePieceProcessor const *self,std::string const &input,float theta){
+    float result;
+    self->CalculateEntropy(input, theta, &result);
+    return result;
   }
 
 SWIGINTERN int
@@ -4164,6 +4183,170 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SampleEncodeAsIds(PyObject *SW
     resultobj = PyList_New((&result)->size());
     for (size_t i = 0; i < (&result)->size(); ++i) {
       PyList_SetItem(resultobj, i, PyInt_FromLong(static_cast<long>(result[i])));
+    }
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SampleEncodeAndScoreAsPieces(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  sentencepiece::SentencePieceProcessor *arg1 = (sentencepiece::SentencePieceProcessor *) 0 ;
+  absl::string_view arg2 ;
+  int arg3 ;
+  float arg4 ;
+  bool arg5 ;
+  bool arg6 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  float val4 ;
+  int ecode4 = 0 ;
+  bool val5 ;
+  int ecode5 = 0 ;
+  bool val6 ;
+  int ecode6 = 0 ;
+  PyObject *swig_obj[6] ;
+  std::vector< std::pair< std::vector< std::string >,float > > result;
+  
+  if (!SWIG_Python_UnpackTuple(args, "SentencePieceProcessor_SampleEncodeAndScoreAsPieces", 6, 6, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_sentencepiece__SentencePieceProcessor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsPieces" "', argument " "1"" of type '" "sentencepiece::SentencePieceProcessor const *""'"); 
+  }
+  arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
+  {
+    const PyInputString ustring(swig_obj[1]);
+    if (!ustring.IsAvalable()) {
+      PyErr_SetString(PyExc_TypeError, "not a string");
+      SWIG_fail;
+    }
+    resultobj = ustring.input_type();
+    arg2 = absl::string_view(ustring.data(), ustring.size());
+  }
+  ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsPieces" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
+  ecode4 = SWIG_AsVal_float(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsPieces" "', argument " "4"" of type '" "float""'");
+  } 
+  arg4 = static_cast< float >(val4);
+  ecode5 = SWIG_AsVal_bool(swig_obj[4], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsPieces" "', argument " "5"" of type '" "bool""'");
+  } 
+  arg5 = static_cast< bool >(val5);
+  ecode6 = SWIG_AsVal_bool(swig_obj[5], &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsPieces" "', argument " "6"" of type '" "bool""'");
+  } 
+  arg6 = static_cast< bool >(val6);
+  {
+    try {
+      result = ((sentencepiece::SentencePieceProcessor const *)arg1)->SampleEncodeAndScoreAsPieces(arg2,arg3,arg4,arg5,arg6);
+      ReleaseResultObject(resultobj);
+    }
+    catch (const sentencepiece::util::Status &status) {
+      SWIG_exception(ToSwigError(status.code()), status.ToString().c_str());
+    }
+  }
+  {
+    PyObject *input_type = resultobj;
+    resultobj = PyList_New((&result)->size());
+    for (size_t i = 0; i < (&result)->size(); ++i) {
+      PyObject *obj = PyList_New(result[i].first.size());
+      for (size_t j = 0; j < result[i].first.size(); ++j) {
+        PyList_SetItem(obj, j, MakePyOutputString(result[i].first[j], input_type));
+      }
+      PyList_SetItem(resultobj, i, PyTuple_Pack(2, obj, PyFloat_FromDouble(static_cast<double>(result[i].second))));
+    }
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SampleEncodeAndScoreAsIds(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  sentencepiece::SentencePieceProcessor *arg1 = (sentencepiece::SentencePieceProcessor *) 0 ;
+  absl::string_view arg2 ;
+  int arg3 ;
+  float arg4 ;
+  bool arg5 ;
+  bool arg6 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  float val4 ;
+  int ecode4 = 0 ;
+  bool val5 ;
+  int ecode5 = 0 ;
+  bool val6 ;
+  int ecode6 = 0 ;
+  PyObject *swig_obj[6] ;
+  std::vector< std::pair< std::vector< int >,float > > result;
+  
+  if (!SWIG_Python_UnpackTuple(args, "SentencePieceProcessor_SampleEncodeAndScoreAsIds", 6, 6, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_sentencepiece__SentencePieceProcessor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsIds" "', argument " "1"" of type '" "sentencepiece::SentencePieceProcessor const *""'"); 
+  }
+  arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
+  {
+    const PyInputString ustring(swig_obj[1]);
+    if (!ustring.IsAvalable()) {
+      PyErr_SetString(PyExc_TypeError, "not a string");
+      SWIG_fail;
+    }
+    resultobj = ustring.input_type();
+    arg2 = absl::string_view(ustring.data(), ustring.size());
+  }
+  ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsIds" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
+  ecode4 = SWIG_AsVal_float(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsIds" "', argument " "4"" of type '" "float""'");
+  } 
+  arg4 = static_cast< float >(val4);
+  ecode5 = SWIG_AsVal_bool(swig_obj[4], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsIds" "', argument " "5"" of type '" "bool""'");
+  } 
+  arg5 = static_cast< bool >(val5);
+  ecode6 = SWIG_AsVal_bool(swig_obj[5], &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "SentencePieceProcessor_SampleEncodeAndScoreAsIds" "', argument " "6"" of type '" "bool""'");
+  } 
+  arg6 = static_cast< bool >(val6);
+  {
+    try {
+      result = ((sentencepiece::SentencePieceProcessor const *)arg1)->SampleEncodeAndScoreAsIds(arg2,arg3,arg4,arg5,arg6);
+      ReleaseResultObject(resultobj);
+    }
+    catch (const sentencepiece::util::Status &status) {
+      SWIG_exception(ToSwigError(status.code()), status.ToString().c_str());
+    }
+  }
+  {
+    PyObject *input_type = resultobj;
+    resultobj = PyList_New((&result)->size());
+    for (size_t i = 0; i < (&result)->size(); ++i) {
+      PyObject *obj = PyList_New(result[i].first.size());
+      for (size_t j = 0; j < result[i].first.size(); ++j) {
+        PyList_SetItem(obj, j, PyInt_FromLong(static_cast<long>(result[i].first[j])));
+      }
+      PyList_SetItem(resultobj, i, PyTuple_Pack(2, obj, PyFloat_FromDouble(static_cast<double>(result[i].second))));
     }
   }
   return resultobj;
@@ -5066,6 +5249,60 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SentencePieceProcessor_EntropyWrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  sentencepiece::SentencePieceProcessor *arg1 = (sentencepiece::SentencePieceProcessor *) 0 ;
+  std::string *arg2 = 0 ;
+  float arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  float val3 ;
+  int ecode3 = 0 ;
+  PyObject *swig_obj[3] ;
+  float result;
+  
+  if (!SWIG_Python_UnpackTuple(args, "SentencePieceProcessor_EntropyWrapper", 3, 3, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_sentencepiece__SentencePieceProcessor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SentencePieceProcessor_EntropyWrapper" "', argument " "1"" of type '" "sentencepiece::SentencePieceProcessor const *""'"); 
+  }
+  arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
+  {
+    const PyInputString ustring(swig_obj[1]);
+    if (!ustring.IsAvalable()) {
+      PyErr_SetString(PyExc_TypeError, "not a string");
+      SWIG_fail;
+    }
+    resultobj = ustring.input_type();
+    arg2 = new std::string(ustring.data(), ustring.size());
+  }
+  ecode3 = SWIG_AsVal_float(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SentencePieceProcessor_EntropyWrapper" "', argument " "3"" of type '" "float""'");
+  } 
+  arg3 = static_cast< float >(val3);
+  {
+    try {
+      result = (float)sentencepiece_SentencePieceProcessor_EntropyWrapper((sentencepiece::SentencePieceProcessor const *)arg1,(std::string const &)*arg2,arg3);
+      ReleaseResultObject(resultobj);
+    }
+    catch (const sentencepiece::util::Status &status) {
+      SWIG_exception(ToSwigError(status.code()), status.ToString().c_str());
+    }
+  }
+  resultobj = SWIG_From_float(static_cast< float >(result));
+  {
+    delete arg2;
+  }
+  return resultobj;
+fail:
+  {
+    delete arg2;
+  }
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *SentencePieceProcessor_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -5414,6 +5651,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "SentencePieceProcessor_NBestEncodeAsIds", _wrap_SentencePieceProcessor_NBestEncodeAsIds, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_SampleEncodeAsPieces", _wrap_SentencePieceProcessor_SampleEncodeAsPieces, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_SampleEncodeAsIds", _wrap_SentencePieceProcessor_SampleEncodeAsIds, METH_VARARGS, NULL},
+	 { "SentencePieceProcessor_SampleEncodeAndScoreAsPieces", _wrap_SentencePieceProcessor_SampleEncodeAndScoreAsPieces, METH_VARARGS, NULL},
+	 { "SentencePieceProcessor_SampleEncodeAndScoreAsIds", _wrap_SentencePieceProcessor_SampleEncodeAndScoreAsIds, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_DecodePieces", _wrap_SentencePieceProcessor_DecodePieces, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_EncodeAsSerializedProto", _wrap_SentencePieceProcessor_EncodeAsSerializedProto, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_SampleEncodeAsSerializedProto", _wrap_SentencePieceProcessor_SampleEncodeAsSerializedProto, METH_VARARGS, NULL},
@@ -5435,6 +5674,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "SentencePieceProcessor_LoadFromFile", _wrap_SentencePieceProcessor_LoadFromFile, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_DecodeIdsWithCheck", _wrap_SentencePieceProcessor_DecodeIdsWithCheck, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_DecodeIdsAsSerializedProtoWithCheck", _wrap_SentencePieceProcessor_DecodeIdsAsSerializedProtoWithCheck, METH_VARARGS, NULL},
+	 { "SentencePieceProcessor_EntropyWrapper", _wrap_SentencePieceProcessor_EntropyWrapper, METH_VARARGS, NULL},
 	 { "SentencePieceProcessor_swigregister", SentencePieceProcessor_swigregister, METH_O, NULL},
 	 { "SentencePieceProcessor_swiginit", SentencePieceProcessor_swiginit, METH_VARARGS, NULL},
 	 { "SetRandomGeneratorSeed", _wrap_SetRandomGeneratorSeed, METH_O, NULL},

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -333,6 +333,42 @@ util::Status SentencePieceProcessor::SampleEncode(absl::string_view input,
   return util::OkStatus();
 }
 
+util::Status SentencePieceProcessor::SampleEncodeAndScore(
+    absl::string_view input, int samples, float theta, bool wor, bool include_best,
+    std::vector<std::pair<std::vector<std::string>, float>> *pieces) const {
+  CHECK_OR_RETURN_STATUS_STL(pieces);
+
+  NBestSentencePieceText spt;
+  RETURN_IF_ERROR(SampleEncodeAndScore(input, samples, theta, wor, include_best, &spt));
+  for (const auto &nbest : spt.nbests()) {
+    std::vector<std::string> result;
+    for (const auto &sp : nbest.pieces()) {
+      result.emplace_back(sp.piece());
+    }
+    pieces->emplace_back(result, nbest.score());
+  }
+
+  return util::OkStatus();
+}
+
+util::Status SentencePieceProcessor::SampleEncodeAndScore(
+    absl::string_view input, int samples, float theta, bool wor, bool include_best,
+    std::vector<std::pair<std::vector<int>, float>> *ids) const {
+  CHECK_OR_RETURN_STATUS_STL(ids);
+
+  NBestSentencePieceText spt;
+  RETURN_IF_ERROR(SampleEncodeAndScore(input, samples, theta, wor, include_best, &spt));
+  for (const auto &nbest : spt.nbests()) {
+    std::vector<int> result;
+    for (const auto &sp : nbest.pieces()) {
+      result.emplace_back(sp.id());
+    }
+    ids->emplace_back(result, nbest.score());
+  }
+
+  return util::OkStatus();
+}
+
 util::Status SentencePieceProcessor::PopulateSentencePieceText(
     absl::string_view input, absl::string_view normalized,
     const std::vector<size_t> &norm_to_orig, const EncodeResult &result,

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -298,6 +298,20 @@ class SentencePieceProcessor {
                                     float alpha, std::vector<int> *ids) const;
 
   //////////////////////////////////////////////////////////////
+  // SampleEncodeAndScore API.
+  // Similar to SampleEncode, but returns samples results.
+  virtual util::Status SampleEncodeAndScore(
+      absl::string_view input, int samples,
+      float theta, bool wor, bool include_best,
+      std::vector<std::pair<std::vector<std::string>, float>> *pieces) const;
+
+  // Same as above, but returns a sequence of ids.
+  virtual util::Status SampleEncodeAndScore(
+      absl::string_view input, int samples,
+      float theta, bool wor, bool include_best,
+      std::vector<std::pair<std::vector<int>, float>> *ids) const;
+
+  //////////////////////////////////////////////////////////////
   // Advanced API returning SentencePieceText, which manages
   // utf8-byte alignments between user-input/detokenized text
   // and internal sentencepiece sequence.
@@ -389,6 +403,22 @@ class SentencePieceProcessor {
                                              float alpha) const {
     DEFINE_SPP_DIRECT_FUNC_IMPL(SampleEncode, std::vector<int>, input,
                                 nbest_size, alpha);
+  }
+
+  virtual std::vector<std::pair<std::vector<std::string>, float>> SampleEncodeAndScoreAsPieces(
+      absl::string_view input, int samples, float theta, bool wor, bool include_best) const {
+    std::vector<std::pair<std::vector<std::string>, float>> output;
+    const auto _status = SampleEncodeAndScore(input, samples, theta, wor, include_best, &output);
+    if (!_status.ok()) throw _status;
+    return output;
+  }
+
+  virtual std::vector<std::pair<std::vector<int>, float>> SampleEncodeAndScoreAsIds(
+      absl::string_view input, int samples, float theta, bool wor, bool include_best) const {
+    std::vector<std::pair<std::vector<int>, float>> output;
+    const auto _status = SampleEncodeAndScore(input, samples, theta, wor, include_best, &output);
+    if (!_status.ok()) throw _status;
+    return output;
   }
 
   virtual std::string DecodePieces(


### PR DESCRIPTION
@kriscao It looks like the code for [You should evaluate your language model on marginal likelihood over tokenisations](https://aclanthology.org/2021.emnlp-main.161/) was added to sentencepiece, but is only exposed through the C++ API. This pull request exposes the `CalculateEntropy` and `SampleEncodeAndScore` methods to python to make it easier to use.

This change necessitated running SWIG, which also updated __init__.py and the .cxx wrapper automatically.

I've tested out these changes locally in the python interpreter where they appear to behave as expected.

NOTE: I have already signed the Google Individual Contributor License Agreement.