### PR TITLE
Update setup.cfg to use underscore for 'description_file' attribute

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Setuptools v54.1.0 introduces a warning that the use of dash-separated options in 'setup.cfg' will not be supported in a future version [1]. Get ahead of the issue by replacing the dashes with underscores. Without this, we see 'UserWarning' messages like the following on new enough versions of setuptools:

```
  UserWarning: Usage of dash-separated 'description-file' will not be
  supported in future versions. Please use the underscore name
  'description_file' instead
```

[1] https://github.com/pypa/setuptools/commit/a2e9ae4cb

Update setup.cfg to use underscore for 'description_file' instead of dash 'description-file' since it loses support in future versions