### PR TITLE
Fix example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For those unfamiliar with SentencePiece as a software/algorithm, one can read [a
 |:---|:---:|:---:|:---:|
 |Supported algorithm|BPE, unigram, char, word|BPE|BPE*|
 |OSS?|Yes|Yes|Google internal|
-|Subword regularization|[Yes](#subword-regularization)|No|No|
+|Subword regularization|[Yes](#subword-regularization-and-bpe-dropout)|No|No|
 |Python Library (pip)|[Yes](python/README.md)|No|N/A|
 |C++ Library|[Yes](doc/api.md)|No|N/A|
 |Pre-segmentation required?|[No](#whitespace-is-treated-as-a-basic-symbol)|Yes|Yes|

--- a/doc/experiments.md
+++ b/doc/experiments.md
@@ -112,7 +112,7 @@ We have evaluated SentencePiece segmentation with the following configurations.
     *   [KFTT](http://www.phontron.com/kftt/index.html)
     *   [MultiUN](http://opus.lingfil.uu.se/MultiUN.php) (First 5M and next
         5k/5k sentences are used for training and development/testing respectively.)
-    *   [WMT16](http://www.statmt.org/WMT16/)
+    *   [WMT16](https://www.statmt.org/wmt16/)
     *   In-house: (Used 5M parallel sentences for training)
 
 **NoPretok** and **WsPretok** do not use any language-dependent resources.

--- a/python/sentencepiece_python_module_example.ipynb
+++ b/python/sentencepiece_python_module_example.ipynb
@@ -216,7 +216,7 @@
         "import tensorflow as tf\n",
         "\n",
         "# Assumes that m.model is stored in non-Posix file system.\n",
-        "serialized_model_proto = tf.gfile.GFile('m.model', 'rb').read()\n",
+        "serialized_model_proto = tf.io.gfile.GFile('m.model', 'rb').read()\n",
         "\n",
         "sp = spm.SentencePieceProcessor()\n",
         "sp.load_from_serialized_proto(serialized_model_proto)\n",
@@ -265,7 +265,7 @@
       },
       "cell_type": "code",
       "source": [
-        "## Example of user defined symbols\n",
+        "# Example of user defined symbols\n",
         "spm.SentencePieceTrainer.train('--input=botchan.txt --model_prefix=m_user --user_defined_symbols=<sep>,<cls> --vocab_size=2000')\n",
         "\n",
         "sp_user = spm.SentencePieceProcessor()\n",
@@ -307,7 +307,7 @@
       },
       "cell_type": "code",
       "source": [
-        "## Example of control symbols\n",
+        "# Example of control symbols\n",
         "spm.SentencePieceTrainer.train('--input=botchan.txt --model_prefix=m_ctrl --control_symbols=<sep>,<cls> --vocab_size=2000')\n",
         "\n",
         "sp_ctrl = spm.SentencePieceProcessor()\n",
@@ -564,7 +564,7 @@
         "spm.SentencePieceTrainer.train('--input=botchan.txt --vocab_size=2000 --model_prefix=m --unk_surface=__UNKNOWN__')\n",
         "sp = spm.SentencePieceProcessor()\n",
         "sp.load('m.model')\n",
-        "print(sp.decode_ids([sp.unk_id()])) "
+        "print(sp.decode_ids([sp.unk_id()]))"
       ],
       "execution_count": 0,
       "outputs": [
@@ -608,7 +608,7 @@
         "# There are two hyperparamenters for sampling (nbest_size and inverse temperature). see the paper [kudo18] for detail.\n",
         "for n in range(10):\n",
         "  print(sp.sample_encode_as_pieces('hello world', -1, 0.1))\n",
-        "  \n",
+        "\n",
         "for n in range(10):\n",
         "  print(sp.sample_encode_as_ids('hello world', -1, 0.1))"
       ],
@@ -858,8 +858,6 @@
       },
       "cell_type": "code",
       "source": [
-        "import sentencepiece as spm\n",
-        "\n",
         "# NFKC normalization and lower casing.\n",
         "spm.SentencePieceTrainer.train('--input=botchan.txt --model_prefix=m --vocab_size=2000 --normalization_rule_name=nfkc_cf')\n",
         "\n",
@@ -903,11 +901,12 @@
       },
       "cell_type": "code",
       "source": [
-        "def tocode(s):                                                                               \n",
-        "    out = []                                                                                 \n",
-        "    for c in s:                                                                              \n",
-        "        out.append(str(hex(ord(c))).replace('0x', 'U+'))                                     \n",
-        "    return ' '.join(out)          \n",
+        "def tocode(s):\n",
+        "    out = []\n",
+        "    for c in s:\n",
+        "        out.append(str(hex(ord(c))).replace('0x', 'U+'))\n",
+        "    return ' '.join(out)\n",
+        "\n",
         "\n",
         "# TSV format:  source Unicode code points <tab> target code points\n",
         "# normalize \"don't => do not,  I'm => I am\"\n",
@@ -923,7 +922,7 @@
         "# m.model embeds the normalization rule compiled into an FST.\n",
         "sp.load('m.model')\n",
         "print(sp.encode_as_pieces(\"I'm busy\"))  # normalzied to `I am busy'\n",
-        "print(sp.encode_as_pieces(\"I don't know it.\"))  # normalized to 'I do not know it.'\n"
+        "print(sp.encode_as_pieces(\"I don't know it.\"))  # normalized to 'I do not know it.'"
       ],
       "execution_count": 0,
       "outputs": [
@@ -1029,9 +1028,9 @@
         "        for piece in sp.encode_as_pieces(line):\n",
         "            freq.setdefault(piece, 0)\n",
         "            freq[piece] += 1\n",
-        "            \n",
+        "\n",
         "# only uses the token appearing more than 1000 times in the training data.\n",
-        "vocabs = list(filter(lambda x : x in freq and freq[x] > 1000, vocabs))\n",
+        "vocabs = list(filter(lambda x: x in freq and freq[x] > 1000, vocabs))\n",
         "sp.set_vocabulary(vocabs)\n",
         "print(sp.encode_as_pieces('this is a test.'))\n",
         "\n",
@@ -1133,20 +1132,17 @@
       },
       "cell_type": "code",
       "source": [
-        "freq={}\n",
+        "freq = {}\n",
         "with open('botchan.txt', 'r') as f:\n",
         "  for line in f:\n",
         "    line = line.rstrip()\n",
         "    for piece in line.split():\n",
         "      freq.setdefault(piece, 0)\n",
         "      freq[piece] += 1\n",
-        "            \n",
+        "\n",
         "with open('word_freq_list.tsv', 'w') as f:\n",
         "  for k, v in freq.items():\n",
         "    f.write('%s\\t%d\\n' % (k, v))\n",
-        "  \n",
-        "\n",
-        "import sentencepiece as spm\n",
         "\n",
         "spm.SentencePieceTrainer.train('--input=word_freq_list.tsv --input_format=tsv --model_prefix=m --vocab_size=2000')\n",
         "sp = spm.SentencePieceProcessor()\n",
@@ -1176,7 +1172,7 @@
         "\n",
         "Sentencepiece keeps track of byte offset (span) of each token, which is useful for highlighting the token on top of unnormalized text.\n",
         "\n",
-        "We first need to install protobuf module and sentencepiece_pb2.py as the byte offsets and all other meta data for segementation are encoded in protocol buffer.\n",
+        "We first need to install protobuf module as the byte offsets and all other meta data for segementation are encoded in protocol buffer.\n",
         "**encode_as_serialized_proto** method resturns serialized SentencePieceText proto. You can get the deserialized object by calling ParseFromString method.\n",
         "\n",
         "The definition of SentencePieceText proto is found [here](https://github.com/google/sentencepiece/blob/3be3f2e11e2bb923c579c6be5e7335809341587f/src/sentencepiece.proto#L23).\n"
@@ -1194,8 +1190,7 @@
       },
       "cell_type": "code",
       "source": [
-        "!pip install protobuf\n",
-        "!wget https://raw.githubusercontent.com/google/sentencepiece/master/python/sentencepiece_pb2.py"
+        "!pip install protobuf"
       ],
       "execution_count": 0,
       "outputs": [
@@ -1233,8 +1228,7 @@
       },
       "cell_type": "code",
       "source": [
-        "import sentencepiece_pb2\n",
-        "import sentencepiece as spm\n",
+        "from sentencepiece import sentencepiece_pb2\n",
         "\n",
         "spm.SentencePieceTrainer.train('--input=botchan.txt --model_prefix=m --vocab_size=2000')\n",
         "\n",


### PR DESCRIPTION
Hi.
Fixed errors in `sentencepiece_python_module_example.ipynb` notebook:
- In 2.0, tf.gfile.* is replaced by tf.io.gfile.*: `tf.io.gfile.GFile` -> `tf**.io**.gfile.GFile`
<img width="467" alt="image" src="https://user-images.githubusercontent.com/36787333/183645014-1a268c28-830b-45e5-8433-8e8d21402554.png">
- error during importing `sentencepiece_pb2`
<img width="467" alt="image" src="https://user-images.githubusercontent.com/36787333/183645795-f8924b33-4a90-4cee-831a-92b2c81e8625.png">
- remove redundant imports

Tested in colab. "Runtime" -> "Run all" without errors.

Also fixed dead links in `README.md` and `doc/experiments.md`.