### PR TITLE
fix the path in add_new_vocab.ipynb

### DIFF
--- a/python/add_new_vocab.ipynb
+++ b/python/add_new_vocab.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "#### You can add new special tokens to pre-trained sentencepiece model\n",
-    "#### Run this code in google/sentencepiece/python/"
+    "#### Run this code in google/sentencepiece/python/src/sentencepiece"
    ]
   },
   {


### PR DESCRIPTION
Hello.

I have noticed that a tutorial that is committed is not working.
This is because the path has changed since this tutorial was [committed](https://github.com/google/sentencepiece/tree/c091f894a8f767e0b15d20720668943a58ab1313/python).

So I want to fix this tutorial.