### PR TITLE
Fix setup-python version not detected

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
         architecture: ${{matrix.arch}}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.5
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Fixes this error:
Build wheels on ubuntu-latest
Unable to resolve action `actions/setup-python@v4.5`, unable to find version `v4.5`

https://github.com/google/sentencepiece/actions/runs/4204923860