### PR TITLE
Removed replacing of /MD with /MT for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 file(STRINGS "VERSION.txt" SPM_VERSION)
 message(STATUS "VERSION: ${SPM_VERSION}")
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(sentencepiece VERSION ${SPM_VERSION} LANGUAGES C CXX)
 
 option(SPM_ENABLE_NFKC_COMPILE "Enables NFKC compile" OFF)
@@ -68,10 +73,6 @@ else()
 endif()
 
 if (MSVC)
-  string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_DEBUG          ${CMAKE_CXX_FLAGS_DEBUG})
-  string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_MINSIZEREL     ${CMAKE_CXX_FLAGS_MINSIZEREL})
-  string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE        ${CMAKE_CXX_FLAGS_RELEASE})
-  string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
   add_definitions("/wd4267 /wd4244 /wd4305 /Zc:strictStrings /utf-8")
 endif()
 


### PR DESCRIPTION
See details in the ticket https://github.com/google/sentencepiece/issues/825#event-8773663277

Since MSVC 2015 the MSVC runtime is compatible. So, we don't have to force users to compile their applications and libraries with static MSVC runtime, while default MSVC behavior is /MD
If someone still needs static runtime, he / she is suggested to use cmake's option designed for this purpose [CMAKE_MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)

Example:
```cmake
cmake -D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded 
```