### PR TITLE
Fix overlinking with protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 if (SPM_USE_BUILTIN_PROTOBUF)
   set(libprotobuf_lite "")
 else()
-  set(libprotobuf_lite "-lprotobuf-lite")
+  set(libprotobuf_lite "protobuf-lite")
 endif()
 
 if (MSVC)

--- a/sentencepiece.pc.in
+++ b/sentencepiece.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir_for_pc_file@
 Name: @PROJECT_NAME@
 Description: Unsupervised text tokenizer and detokenizer for Neural Network-based text generation.
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -lsentencepiece -lsentencepiece_train @libprotobuf_lite@
+Libs: -L${libdir} -lsentencepiece -lsentencepiece_train
 Cflags: -I${includedir}
+Requires.private: @libprotobuf_lite@

--- a/sentencepiece.pc.in
+++ b/sentencepiece.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir_for_pc_file@
 Name: @PROJECT_NAME@
 Description: Unsupervised text tokenizer and detokenizer for Neural Network-based text generation.
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -lsentencepiece -lsentencepiece_train @libprotobuf_lite@ @pkgconfiglibs@
-Cflags: -I${includedir} @pkgconfigcflags@
+Libs: -L${libdir} -lsentencepiece -lsentencepiece_train @libprotobuf_lite@
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR fixes the pkg-config file so that it does not suggest linking with libprotobuf-lite (when sentencepiece has been configured for external protobuf using `-DSPM_USE_BUILTIN_PROTOBUF=OFF`) unless static linking is requested.

While I was there, I also removed some unused placeholders.


### Before:

```sh
% pkg-config sentencepiece --libs
-L/opt/local/lib -lsentencepiece -lsentencepiece_train -lprotobuf-lite
% pkg-config sentencepiece --libs --static
-L/opt/local/lib -lsentencepiece -lsentencepiece_train -lprotobuf-lite
```

### After:

```sh
% pkg-config sentencepiece --libs
-L/opt/local/lib -lsentencepiece -lsentencepiece_train
% pkg-config sentencepiece --libs --static
-L/opt/local/lib -lsentencepiece -lsentencepiece_train -lprotobuf-lite
```
