### PR TITLE
Hash-pin GitHub Actions, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
         python-version: '3.x'
         architecture: ${{matrix.arch}}
@@ -60,13 +60,13 @@ jobs:
         python setup.py bdist_wheel
 
     - name: Upload artifcacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         path: ./build/*.7z
 
     - name: Upload Release Assets
       if: startsWith(github.ref, 'refs/tags/')
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./build/*.7z

--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -17,7 +17,7 @@ jobs:
         arch: [ i686, arm, aarch64, riscv64, powerpc, powerpc64, powerpc64le, s390x, sparc64, m68k, sh4, alpha ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Install cross tools
       run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -21,14 +21,14 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: "3.x"
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
         with:
           platforms: arm64
 
@@ -69,7 +69,7 @@ jobs:
         run: sh build_sdist.sh
 
       - name: Fetch sdist archive
-        uses: tj-actions/glob@v17
+        uses: tj-actions/glob@ac7d983dd3677ab0879d703cfdbde78676cdfaad # v17.3.0
         id: sdist
         with:
           files: ./python/dist/*.tar.gz
@@ -83,7 +83,7 @@ jobs:
         run: cp -f dist/*.tar.gz wheelhouse/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: |
             ./python/wheelhouse/*.whl
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload wheel release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./python/wheelhouse/*


### PR DESCRIPTION
Fixes #.

As described in the issue, this PR hash-pins the GitHub Actions used in the workflows to protect the project from supply-chain attacks.

The only exception are the oss-fuzz Actions which unfortunately require running `@master` to work properly.

This PR also adds Dependabot to keep the Actions up-to-date. It is configured to send at most one PR a month updating all Actions with new versions.