### PR TITLE
Set minimal permissions for GitHub workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -18,6 +21,9 @@ jobs:
           - os: windows-latest
             arch: x86
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write # svenstaro/upload-release-action 
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
     outputs:
@@ -19,6 +22,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-11]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}
+
+    permissions:
+      contents: write # svenstaro/upload-release-action 
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-          python -m pip install cibuildwheel==2.12.0
+          python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         working-directory: ${{github.workspace}}/python


### PR DESCRIPTION
Fixes #937.

This PR sets read-only top-level permissions on all SentencePiece workflows. The jobs that add artifacts to releases (in `cmake.yml` and `wheel.yml`) are granted additional permissions at the job level for future-proofing in case new jobs are ever added to the workflow.