### PR TITLE
Add missing output formats to spm_encode flag documentation

### DIFF
--- a/src/spm_encode_main.cc
+++ b/src/spm_encode_main.cc
@@ -30,7 +30,8 @@
 ABSL_FLAG(std::string, model, "", "model file name");
 ABSL_FLAG(
     std::string, output_format, "piece",
-    "choose from piece, id, proto, nbest_piece, nbest_id, or nbest_proto");
+    "choose from piece, id, proto, sample_piece, sample_id, sample_proto, "
+    "nbest_piece, nbest_id, or nbest_proto");
 ABSL_FLAG(std::string, input, "", "input filename");
 ABSL_FLAG(std::string, output, "", "output filename");
 ABSL_FLAG(std::string, extra_options, "",


### PR DESCRIPTION
`sample_(piece|id|proto)` was listed in the github README but not in the actual flag docs, and so it was hard to know how to do subword regularization from the command line.