### PR TITLE
make it more friendly for mingw enviroments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (SPM_CROSS_SYSTEM_PROCESSOR)
 endif()
 
 # Disable shared build on windows
-if(WIN32)
+if(MSVC)
   set(SPM_ENABLE_SHARED OFF)
 endif()
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -102,8 +102,7 @@ class build_ext(_build_ext):
     ext.extra_link_args = libs
     _build_ext.build_extension(self, ext)
 
-
-if os.name == 'nt':
+if os.name == 'nt' and not os.environ.get('SENTENCEPIECE_MINGW_SKIP'):
   # Must pre-install sentencepice into build directory.
   arch = 'win32'
   if sys.maxsize > 2**32:


### PR DESCRIPTION
to #1006 in msys2 enviroment
build it as
```
cmake -DCMAKE_INSTALL_PREFIX=/mingw64/ -B build
cmake --build build --target install
```
then on python directory
```
SENTENCEPIECE_MINGW_SKIP=true python -m build --wheel --no-isolation --skip-dependency-check
python -m installer --prefix=/mingw64/  dist/*.whl
```
![image](https://github.com/google/sentencepiece/assets/2415206/86a306a3-9ff0-4d17-818c-0e35138d35c7)
