### PR TITLE
Parameterize lattice node allocator size to optimize chunk allocation performance

### DIFF
--- a/src/bpe_model.cc
+++ b/src/bpe_model.cc
@@ -36,7 +36,7 @@ Model::Model(const ModelProto &model_proto) {
 Model::~Model() {}
 
 std::vector<std::pair<absl::string_view, int>> Model::SampleEncode(
-    absl::string_view normalized, float alpha) const {
+    absl::string_view normalized, float alpha, int /*nodeAllocatorSize*/) const {
   if (!status().ok() || normalized.empty()) {
     return {};
   }

--- a/src/bpe_model.h
+++ b/src/bpe_model.h
@@ -32,8 +32,8 @@ class Model : public ModelInterface {
   explicit Model(const ModelProto &model_proto);
   ~Model() override;
 
-  EncodeResult Encode(absl::string_view normalized) const override {
-    return SampleEncode(normalized, 0.0);
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const override {
+    return SampleEncode(normalized, 0.0, nodeAllocatorSize);
   }
 
   // Sampling with BPE-dropout: https://arxiv.org/pdf/1910.13267.pdf
@@ -41,7 +41,8 @@ class Model : public ModelInterface {
   // Skips merge operation with `alpha` probability.
   // When alpha <= 0.0, no sampling is performed.
   EncodeResult SampleEncode(absl::string_view normalized,
-                            float alpha) const override;
+                            float alpha,
+                            int nodeAllocatorSize = 0) const override;
 
   bool IsSampleEncodeAvailable() const override { return true; }
 

--- a/src/char_model.cc
+++ b/src/char_model.cc
@@ -25,7 +25,7 @@ Model::Model(const ModelProto &model_proto) {
 
 Model::~Model() {}
 
-EncodeResult Model::Encode(absl::string_view normalized) const {
+EncodeResult Model::Encode(absl::string_view normalized, int /* nodeAllocatorSize */) const {
   if (!status().ok() || normalized.empty()) {
     return {};
   }

--- a/src/char_model.h
+++ b/src/char_model.h
@@ -27,7 +27,7 @@ class Model : public ModelInterface {
   explicit Model(const ModelProto &model_proto);
   ~Model() override;
 
-  EncodeResult Encode(absl::string_view normalized) const override;
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const override;
 };
 }  // namespace character
 }  // namespace sentencepiece

--- a/src/model_interface.h
+++ b/src/model_interface.h
@@ -79,17 +79,19 @@ class ModelInterface {
 
   // Given a normalized string, returns a sequence of sentence pieces with ids.
   // The concatenation of pieces must be the same as `normalized`.
-  virtual EncodeResult Encode(absl::string_view normalized) const = 0;
+  virtual EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const = 0;
 
   // The same as above, but returns nbest result with score.
   virtual NBestEncodeResult NBestEncode(absl::string_view normalized,
-                                        int nbest_size) const {
+                                        int nbest_size, 
+                                        int nodeAllocatorSize = 0) const {
     LOG(ERROR) << "Not implemented.";
     return NBestEncodeResult();
   }
 
   virtual EncodeResult SampleEncode(absl::string_view normalized,
-                                    float alpha) const {
+                                    float alpha,
+                                    int nodeAllocatorSize = 0) const {
     LOG(ERROR) << "Not implemented.";
     return EncodeResult();
   }
@@ -104,7 +106,8 @@ class ModelInterface {
   virtual NBestEncodeResult SampleEncodeAndScore(absl::string_view normalized,
                                                  float alpha, int samples,
                                                  bool wor,
-                                                 bool include_best) const {
+                                                 bool include_best,
+                                                 int nodeAllocatorSize = 0) const {
     LOG(ERROR) << "Not implemented.";
     return {{EncodeResult(), 0.0}};
   }
@@ -112,7 +115,8 @@ class ModelInterface {
   // Calculates the entropy of the segmentation lattice with inverse temperature
   // `alpha`. Uses a novel dynamic program to calculate the entropy.
   virtual float CalculateEntropy(absl::string_view normalized,
-                                 float alpha) const {
+                                 float alpha,
+                                 int nodeAllocatorSize = 0) const {
     LOG(ERROR) << "Not implemented.";
     return 0.0;
   }

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -377,11 +377,11 @@ util::Status SentencePieceProcessor::LoadVocabulary(absl::string_view filename,
 //////////////////////////////////////////////////////////////
 // Simple API.
 util::Status SentencePieceProcessor::Encode(
-    absl::string_view input, std::vector<std::string> *pieces) const {
+    absl::string_view input, std::vector<std::string> *pieces, int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(pieces);
 
   SentencePieceText spt;
-  RETURN_IF_ERROR(Encode(input, &spt));
+  RETURN_IF_ERROR(Encode(input, &spt, nodeAllocatorSize));
   for (const auto &sp : spt.pieces()) {
     pieces->emplace_back(sp.piece());
   }
@@ -390,11 +390,12 @@ util::Status SentencePieceProcessor::Encode(
 }
 
 util::Status SentencePieceProcessor::Encode(absl::string_view input,
-                                            std::vector<int> *ids) const {
+                                            std::vector<int> *ids,
+                                            int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(ids);
 
   SentencePieceText spt;
-  RETURN_IF_ERROR(Encode(input, &spt));
+  RETURN_IF_ERROR(Encode(input, &spt,nodeAllocatorSize));
   for (const auto &sp : spt.pieces()) {
     ids->emplace_back(sp.id());
   }
@@ -432,11 +433,12 @@ util::Status SentencePieceProcessor::Decode(const std::vector<int> &ids,
 
 util::Status SentencePieceProcessor::NBestEncode(
     absl::string_view input, int nbest_size,
-    std::vector<std::vector<std::string>> *pieces) const {
+    std::vector<std::vector<std::string>> *pieces,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(pieces);
 
   NBestSentencePieceText spt;
-  RETURN_IF_ERROR(NBestEncode(input, nbest_size, &spt));
+  RETURN_IF_ERROR(NBestEncode(input, nbest_size, &spt, nodeAllocatorSize));
   for (const auto &nbest : spt.nbests()) {
     std::vector<std::string> result;
     for (const auto &sp : nbest.pieces()) {
@@ -450,11 +452,12 @@ util::Status SentencePieceProcessor::NBestEncode(
 
 util::Status SentencePieceProcessor::NBestEncode(
     absl::string_view input, int nbest_size,
-    std::vector<std::vector<int>> *ids) const {
+    std::vector<std::vector<int>> *ids,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(ids);
 
   NBestSentencePieceText spt;
-  RETURN_IF_ERROR(NBestEncode(input, nbest_size, &spt));
+  RETURN_IF_ERROR(NBestEncode(input, nbest_size, &spt, nodeAllocatorSize));
   for (const auto &nbest : spt.nbests()) {
     std::vector<int> result;
     for (const auto &sp : nbest.pieces()) {
@@ -468,11 +471,12 @@ util::Status SentencePieceProcessor::NBestEncode(
 
 util::Status SentencePieceProcessor::SampleEncode(
     absl::string_view input, int nbest_size, float alpha,
-    std::vector<std::string> *pieces) const {
+    std::vector<std::string> *pieces,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(pieces);
 
   SentencePieceText spt;
-  RETURN_IF_ERROR(SampleEncode(input, nbest_size, alpha, &spt));
+  RETURN_IF_ERROR(SampleEncode(input, nbest_size, alpha, &spt, nodeAllocatorSize));
   for (const auto &sp : spt.pieces()) {
     pieces->emplace_back(sp.piece());
   }
@@ -482,11 +486,12 @@ util::Status SentencePieceProcessor::SampleEncode(
 
 util::Status SentencePieceProcessor::SampleEncode(absl::string_view input,
                                                   int nbest_size, float alpha,
-                                                  std::vector<int> *ids) const {
+                                                  std::vector<int> *ids,
+                                                  int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(ids);
 
   SentencePieceText spt;
-  RETURN_IF_ERROR(SampleEncode(input, nbest_size, alpha, &spt));
+  RETURN_IF_ERROR(SampleEncode(input, nbest_size, alpha, &spt, nodeAllocatorSize));
   for (const auto &sp : spt.pieces()) {
     ids->emplace_back(sp.id());
   }
@@ -497,12 +502,13 @@ util::Status SentencePieceProcessor::SampleEncode(absl::string_view input,
 util::Status SentencePieceProcessor::SampleEncodeAndScore(
     absl::string_view input, int num_samples, float alpha, bool wor,
     bool include_best,
-    std::vector<std::pair<std::vector<std::string>, float>> *pieces) const {
+    std::vector<std::pair<std::vector<std::string>, float>> *pieces,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(pieces);
 
   NBestSentencePieceText spt;
   RETURN_IF_ERROR(
-      SampleEncodeAndScore(input, num_samples, alpha, wor, include_best, &spt));
+      SampleEncodeAndScore(input, num_samples, alpha, wor, include_best, &spt, nodeAllocatorSize));
 
   pieces->clear();
   pieces->reserve(spt.nbests_size());
@@ -522,12 +528,13 @@ util::Status SentencePieceProcessor::SampleEncodeAndScore(
 util::Status SentencePieceProcessor::SampleEncodeAndScore(
     absl::string_view input, int num_samples, float alpha, bool wor,
     bool include_best,
-    std::vector<std::pair<std::vector<int>, float>> *ids) const {
+    std::vector<std::pair<std::vector<int>, float>> *ids,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_STL(ids);
 
   NBestSentencePieceText spt;
   RETURN_IF_ERROR(
-      SampleEncodeAndScore(input, num_samples, alpha, wor, include_best, &spt));
+      SampleEncodeAndScore(input, num_samples, alpha, wor, include_best, &spt, nodeAllocatorSize));
 
   ids->clear();
   ids->reserve(spt.nbests_size());
@@ -636,14 +643,15 @@ util::Status SentencePieceProcessor::PopulateSentencePieceText(
 }  // namespace sentencepiece
 
 util::Status SentencePieceProcessor::Encode(absl::string_view input,
-                                            SentencePieceText *spt) const {
+                                            SentencePieceText *spt,
+                                            int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_PROTO(spt);
 
   std::string normalized;
   std::vector<size_t> norm_to_orig;
   RETURN_IF_ERROR(normalizer_->Normalize(input, &normalized, &norm_to_orig));
 
-  const auto result = model_->Encode(normalized);
+  const auto result = model_->Encode(normalized, nodeAllocatorSize);
   RETURN_IF_ERROR(
       PopulateSentencePieceText(input, normalized, norm_to_orig, result, spt));
 
@@ -652,7 +660,8 @@ util::Status SentencePieceProcessor::Encode(absl::string_view input,
 
 util::Status SentencePieceProcessor::NBestEncode(
     absl::string_view input, int nbest_size,
-    NBestSentencePieceText *nbest_spt) const {
+    NBestSentencePieceText *nbest_spt,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_PROTO(nbest_spt);
 
   std::string normalized;
@@ -662,7 +671,7 @@ util::Status SentencePieceProcessor::NBestEncode(
   CHECK_OR_RETURN(model_->IsNBestEncodeAvailable())
       << "NBestEncode is not available for the current model.";
 
-  const auto nbests = model_->NBestEncode(normalized, nbest_size);
+  const auto nbests = model_->NBestEncode(normalized, nbest_size,nodeAllocatorSize);
   CHECK_OR_RETURN(!nbests.empty()) << "NBestEncode returns empty result.";
 
   for (const auto &result : nbests) {
@@ -677,7 +686,8 @@ util::Status SentencePieceProcessor::NBestEncode(
 
 util::Status SentencePieceProcessor::SampleEncode(
     absl::string_view input, int nbest_size, float alpha,
-    SentencePieceText *spt) const {
+    SentencePieceText *spt,
+    int nodeAllocatorSize) const {
   CHECK_OR_RETURN_STATUS_PROTO(spt);
 
   CHECK_LE_OR_RETURN(nbest_size, 512) << "nbest_size must be nbest_size <= 512";
@@ -689,15 +699,15 @@ util::Status SentencePieceProcessor::SampleEncode(
   if (!model_->IsNBestEncodeAvailable() || nbest_size < 0) {
     CHECK_OR_RETURN(model_->IsSampleEncodeAvailable())
         << "SampleEncode is not available for the current model.";
-    const auto result = model_->SampleEncode(normalized, alpha);
+    const auto result = model_->SampleEncode(normalized, alpha, nodeAllocatorSize);
     RETURN_IF_ERROR(PopulateSentencePieceText(input, normalized, norm_to_orig,
                                               result, spt));
   } else if (nbest_size == 1 || nbest_size == 0) {
-    const auto result = model_->Encode(normalized);
+    const auto result = model_->Encode(normalized,nodeAllocatorSize);
     RETURN_IF_ERROR(PopulateSentencePieceText(input, normalized, norm_to_orig,
                                               result, spt));
   } else if (nbest_size > 1) {
-    const auto nbests = model_->NBestEncode(normalized, nbest_size);
+    const auto nbests = model_->NBestEncode(normalized, nbest_size, nodeAllocatorSize);
     CHECK_OR_RETURN(!nbests.empty()) << "NBestEncode returns empty result.";
 
     std::vector<double> log_probs;
@@ -723,7 +733,7 @@ util::Status SentencePieceProcessor::SampleEncode(
 
 util::Status SentencePieceProcessor::SampleEncodeAndScore(
     absl::string_view input, int samples, float alpha, bool wor,
-    bool include_best, NBestSentencePieceText *samples_spt) const {
+    bool include_best, NBestSentencePieceText *samples_spt, int nodeAllocatorSize) const {
   CHECK_OR_RETURN(model_->IsSampleEncodeAndScoreAvailable())
       << "SampleEncodeAndScore is not available for the current model.";
   std::string normalized;
@@ -731,7 +741,7 @@ util::Status SentencePieceProcessor::SampleEncodeAndScore(
   RETURN_IF_ERROR(normalizer_->Normalize(input, &normalized, &norm_to_orig));
 
   const auto results = model_->SampleEncodeAndScore(normalized, alpha, samples,
-                                                    wor, include_best);
+                                                    wor, include_best, nodeAllocatorSize);
   CHECK_OR_RETURN(!results.empty())
       << "SampleEncodeAndScore returns empty result.";
 
@@ -747,14 +757,15 @@ util::Status SentencePieceProcessor::SampleEncodeAndScore(
 
 util::Status SentencePieceProcessor::CalculateEntropy(absl::string_view input,
                                                       float alpha,
-                                                      float *entropy) const {
+                                                      float *entropy,
+                                                      int nodeAllocatorSize) const {
   CHECK_OR_RETURN(model_->IsCalculateEntropyAvailable())
       << "CalculateEntropy is not available for the current model.";
   std::string normalized;
   std::vector<size_t> norm_to_orig;
   RETURN_IF_ERROR(normalizer_->Normalize(input, &normalized, &norm_to_orig));
 
-  *entropy = model_->CalculateEntropy(normalized, alpha);
+  *entropy = model_->CalculateEntropy(normalized, alpha, nodeAllocatorSize);
   return util::OkStatus();
 }
 

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -293,11 +293,13 @@ class SentencePieceProcessor {
   //
   // Given a UTF8 input, encodes it into a sequence of sentence pieces.
   virtual util::Status Encode(absl::string_view input,
-                              std::vector<std::string> *pieces) const;
+                              std::vector<std::string> *pieces,
+                              int nodeAllocatorSize = 0) const;
 
   // Given a UTF8 input, encodes it into a sequence of ids.
   virtual util::Status Encode(absl::string_view input,
-                              std::vector<int> *ids) const;
+                              std::vector<int> *ids,
+                              int nodeAllocatorSize = 0) const;
 
   // Given a sequence of pieces, decodes it into a detokenized output.
   virtual util::Status Decode(const std::vector<std::string> &pieces,
@@ -317,11 +319,13 @@ class SentencePieceProcessor {
   // Same as Encode, but returns nbest results.
   virtual util::Status NBestEncode(
       absl::string_view input, int nbest_size,
-      std::vector<std::vector<std::string>> *pieces) const;
+      std::vector<std::vector<std::string>> *pieces,
+      int nodeAllocatorSize = 0) const;
 
   // Same as Encode, but returns nbest results.
   virtual util::Status NBestEncode(absl::string_view input, int nbest_size,
-                                   std::vector<std::vector<int>> *ids) const;
+                                   std::vector<std::vector<int>> *ids,
+                                   int nodeAllocatorSize = 0) const;
 
   //////////////////////////////////////////////////////////////
   // Sampling API.
@@ -345,11 +349,13 @@ class SentencePieceProcessor {
   // nbest_size parameter is ignored in BPE.
   virtual util::Status SampleEncode(absl::string_view input, int nbest_size,
                                     float alpha,
-                                    std::vector<std::string> *pieces) const;
+                                    std::vector<std::string> *pieces,
+                                    int nodeAllocatorSize = 0) const;
 
   // Same as above, but returns a sequence of ids.
   virtual util::Status SampleEncode(absl::string_view input, int nbest_size,
-                                    float alpha, std::vector<int> *ids) const;
+                                    float alpha, std::vector<int> *ids,
+                                    int nodeAllocatorSize = 0) const;
 
   //////////////////////////////////////////////////////////////
   // SampleEncodeAndScore API.
@@ -369,13 +375,15 @@ class SentencePieceProcessor {
   virtual util::Status SampleEncodeAndScore(
       absl::string_view input, int num_samples, float alpha, bool wor,
       bool include_best,
-      std::vector<std::pair<std::vector<std::string>, float>> *pieces) const;
+      std::vector<std::pair<std::vector<std::string>, float>> *pieces,
+      int nodeAllocatorSize = 0) const;
 
   // Same as above, but returns a sequence of ids.
   virtual util::Status SampleEncodeAndScore(
       absl::string_view input, int num_samples, float alpha, bool wor,
       bool include_best,
-      std::vector<std::pair<std::vector<int>, float>> *ids) const;
+      std::vector<std::pair<std::vector<int>, float>> *ids,
+      int nodeAllocatorSize = 0) const;
 
   //////////////////////////////////////////////////////////////
   // Entropy API.
@@ -383,7 +391,8 @@ class SentencePieceProcessor {
   // This only available in model_type=unigram.
   // Calculate entropy of possible tokenisations
   virtual util::Status CalculateEntropy(absl::string_view input, float alpha,
-                                        float *entropy) const;
+                                        float *entropy,
+                                        int nodeAllocatorSize = 0) const;
 
   //////////////////////////////////////////////////////////////
   // Advanced API returning SentencePieceText, which manages
@@ -399,17 +408,21 @@ class SentencePieceProcessor {
   // Encode("hello", spt.mutable_proto()).IgnoreError();
   // std::cout << spt.pieces_size() << std::endl;
   virtual util::Status Encode(absl::string_view input,
-                              SentencePieceText *spt) const;
+                              SentencePieceText *spt,
+                              int nodeAllocatorSize = 0) const;
 
   virtual util::Status NBestEncode(absl::string_view input, int nbest_size,
-                                   NBestSentencePieceText *nbest_spt) const;
+                                   NBestSentencePieceText *nbest_spt,
+                                   int nodeAllocatorSize = 0) const;
 
   virtual util::Status SampleEncode(absl::string_view input, int nbest_size,
-                                    float alpha, SentencePieceText *spt) const;
+                                    float alpha, SentencePieceText *spt,
+                                    int nodeAllocatorSize = 0) const;
 
   virtual util::Status SampleEncodeAndScore(
       absl::string_view input, int num_samples, float alpha, bool wor,
-      bool include_best, NBestSentencePieceText *samples_spt) const;
+      bool include_best, NBestSentencePieceText *samples_spt,
+      int nodeAllocatorSize = 0) const;
 
   // DEPRECATED: Remove this API and use std::vector<std::string_view>
   virtual util::Status Decode(const std::vector<std::string> &pieces,
@@ -525,19 +538,21 @@ class SentencePieceProcessor {
   // They are used in Python interface. Returns serialized proto.
   // In python module, we can get access to the full Proto after
   // deserialzing the returned byte sequence.
-  virtual util::bytes EncodeAsSerializedProto(absl::string_view input) const {
+  virtual util::bytes EncodeAsSerializedProto(absl::string_view input, int nodeAllocatorSize = 0) const {
     DEFINE_SPP_SERIALIZED_PROTO_IMPL(Encode, ImmutableSentencePieceText, input);
   }
 
   virtual util::bytes SampleEncodeAsSerializedProto(absl::string_view input,
                                                     int nbest_size,
-                                                    float alpha) const {
+                                                    float alpha,
+                                                    int nodeAllocatorSize = 0) const {
     DEFINE_SPP_SERIALIZED_PROTO_IMPL(SampleEncode, ImmutableSentencePieceText,
                                      input, nbest_size, alpha);
   }
 
   virtual util::bytes NBestEncodeAsSerializedProto(absl::string_view input,
-                                                   int nbest_size) const {
+                                                   int nbest_size,
+                                                   int nodeAllocatorSize = 0) const {
     DEFINE_SPP_SERIALIZED_PROTO_IMPL(
         NBestEncode, ImmutableNBestSentencePieceText, input, nbest_size);
   }

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -47,18 +47,18 @@ class MockModel : public ModelInterface {
     nbest_output_ = output;
   }
 
-  EncodeResult Encode(absl::string_view normalized) const {
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize) const {
     EXPECT_EQ(normalized, input_);
     return output_;
   }
 
-  EncodeResult SampleEncode(absl::string_view normalized, float alpha) const {
+  EncodeResult SampleEncode(absl::string_view normalized, float alpha, int nodeAllocatorSize) const {
     EXPECT_EQ(normalized, input_);
     return output_;
   }
 
   NBestEncodeResult NBestEncode(absl::string_view normalized,
-                                int nbest_size) const {
+                                int nbest_size, int nodeAllocatorSize) const {
     EXPECT_EQ(normalized, input_);
     return nbest_output_;
   }
@@ -544,7 +544,7 @@ TEST(SentencepieceProcessorTest, SampleEncodeTest) {
 TEST(SentencepieceProcessorTest, DecodeTest) {
   class DecodeMockModel : public ModelInterface {
    public:
-    EncodeResult Encode(absl::string_view normalized) const override {
+    EncodeResult Encode(absl::string_view normalized, int /* nodeAllocatorSize */) const override {
       return {};
     }
 
@@ -711,7 +711,7 @@ TEST(SentencepieceProcessorTest, DecodeTest) {
 TEST(SentencepieceProcessorTest, DummyPrefixDecodeTest) {
   class DecodeMockModel : public ModelInterface {
    public:
-    EncodeResult Encode(absl::string_view normalized) const override {
+    EncodeResult Encode(absl::string_view normalized, int /* nodeAllocatorSize */) const override {
       return {};
     }
 
@@ -791,7 +791,7 @@ TEST(SentencepieceProcessorTest, DummyPrefixDecodeTest) {
 TEST(SentencepieceProcessorTest, ByteFallbackDecodeTest) {
   class ByteFallbackDecodeMockModel : public ModelInterface {
    public:
-    EncodeResult Encode(absl::string_view normalized) const override {
+    EncodeResult Encode(absl::string_view normalized, int /* nodeAllocatorSize */) const override {
       return {};
     }
 

--- a/src/unigram_model.h
+++ b/src/unigram_model.h
@@ -32,7 +32,7 @@ namespace unigram {
 // Lattice represents a search space of sentence piece segmentation.
 class Lattice {
  public:
-  Lattice();
+  Lattice(int nodeAllocatorSize = 0);
   virtual ~Lattice();
 
   struct Node {
@@ -130,20 +130,24 @@ class Model : public ModelInterface {
   Model() {}
   ~Model() override;
 
-  EncodeResult Encode(absl::string_view normalized) const override;
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const override;
 
   NBestEncodeResult NBestEncode(absl::string_view normalized,
-                                int nbest_size) const override;
+                                int nbest_size,
+                                int nodeAllocatorSize = 0) const override;
 
   EncodeResult SampleEncode(absl::string_view normalized,
-                            float theta) const override;
+                            float theta,
+                            int nodeAllocatorSize = 0) const override;
 
   NBestEncodeResult SampleEncodeAndScore(absl::string_view normalized,
                                          float theta, int samples, bool wor,
-                                         bool include_best) const override;
+                                         bool include_best,
+                                         int nodeAllocatorSize = 0) const override;
 
   float CalculateEntropy(absl::string_view normalized,
-                         float theta) const override;
+                         float theta,
+                         int nodeAllocatorSize) const override;
 
   bool IsSampleEncodeAvailable() const override { return true; }
 

--- a/src/unigram_model_trainer.h
+++ b/src/unigram_model_trainer.h
@@ -49,7 +49,7 @@ class TrainerModel : public Model {
   // The meta symbols, e.g., </s> are NOT included.
   void SetSentencePieces(SentencePieces &&sentencepieces);
 
-  EncodeResult Encode(absl::string_view normalized) const override {
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const override {
     return {};
   }
 

--- a/src/word_model.cc
+++ b/src/word_model.cc
@@ -25,7 +25,7 @@ Model::Model(const ModelProto &model_proto) {
 
 Model::~Model() {}
 
-EncodeResult Model::Encode(absl::string_view normalized) const {
+EncodeResult Model::Encode(absl::string_view normalized, int /* nodeAllocatorSize */) const {
   if (!status().ok() || normalized.empty()) {
     return {};
   }

--- a/src/word_model.h
+++ b/src/word_model.h
@@ -27,7 +27,7 @@ class Model : public ModelInterface {
   explicit Model(const ModelProto &model_proto);
   ~Model() override;
 
-  EncodeResult Encode(absl::string_view normalized) const override;
+  EncodeResult Encode(absl::string_view normalized, int nodeAllocatorSize = 0) const override;
 };
 }  // namespace word
 }  // namespace sentencepiece


### PR DESCRIPTION
Lattice node_allocator_ allocates chunks of 1024 items, which is 49 152 bytes total.
This huge size of chunk causes performance issues in high qps environments.
Our internal tests shows significant latency reduction is we can parametrize default chunk size for your needs.