### PR TITLE
Add support for windows arm64

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -45,6 +45,8 @@ jobs:
           cmake --build ${{github.workspace}}/build_win32 --config Release --target install --parallel 8
           cmake -A x64   -B ${{github.workspace}}/build_amd64 -DSPM_ENABLE_SHARED=OFF -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/root_amd64
           cmake --build ${{github.workspace}}/build_amd64 --config Release --target install --parallel 8
+          cmake -A arm64 -B ${{github.workspace}}/build_arm64 -DSPM_ENABLE_SHARED=OFF -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/root_arm64
+          cmake --build ${{github.workspace}}/build_arm64 --config Release --target install --parallel 8
 
       - name: Build for Mac
         if: runner.os == 'macOS'
@@ -66,6 +68,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+          CIBW_ARCHS_WINDOWS: auto ARM64
           CIBW_SKIP: "pp* *-musllinux_*"
           CIBW_BUILD_VERBOSITY: 1
 

--- a/python/README.md
+++ b/python/README.md
@@ -3,7 +3,7 @@
 Python wrapper for SentencePiece. This API will offer the encoding, decoding and training of Sentencepiece.
 
 ## Build and Install SentencePiece
-For Linux (x64/i686), macOS, and Windows(win32/x64) environment, you can simply use pip command to install SentencePiece python module.
+For Linux (x64/i686), macOS, and Windows(win32/x64/arm64) environment, you can simply use pip command to install SentencePiece python module.
 
 ```
 % pip install sentencepiece
@@ -25,6 +25,20 @@ To build and install the Python wrapper from source, try the following commands 
 If you don’t have write permission to the global site-packages directory or don’t want to install into it, please try:
 ```
 % python setup.py install --user
+```
+
+For Windows users who want to build from source, you can build and install the Python wrapper using Visual Studio. First, you need to install the `pwsh.exe` (Powershell 7). Use `winget install --id Microsoft.Powershell --source winget` to install directly. Then open the `Developer PowerShell for VS 2022`, and execute the following commands. 
+```
+git clone https://github.com/google/sentencepiece.git
+cd sentencepiece
+mkdir build
+cd build
+cmake .. -DSPM_ENABLE_SHARED=OFF -DCMAKE_INSTALL_PREFIX=".\root" 
+cmake --build . --config Release --target install
+cd ../python
+pip install wheel
+python setup.py bdist_wheel
+Get-ChildItem .\dist\sentencepiece*.whl | ForEach-Object { pip install $_.FullName }
 ```
 
 ## Usage

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,7 @@ import os
 import string
 import subprocess
 import sys
+import platform
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
@@ -108,6 +109,8 @@ if os.name == 'nt':
   arch = 'win32'
   if sys.maxsize > 2**32:
     arch = 'amd64'
+  if 'arm' in platform.machine().lower():
+    arch = 'arm64'
   if os.path.exists('..\\build\\root_{}\\lib'.format(arch)):
     cflags = ['/std:c++17', '/I..\\build\\root_{}\\include'.format(arch)]
     libs = [
@@ -125,6 +128,8 @@ if os.name == 'nt':
     cmake_arch = 'Win32'
     if arch == 'amd64':
       cmake_arch = 'x64'
+    elif arch == "arm64":
+      cmake_arch = "ARM64"
     subprocess.check_call([
         'cmake',
         'sentencepiece',

--- a/python/setup.py
+++ b/python/setup.py
@@ -104,13 +104,21 @@ class build_ext(_build_ext):
     _build_ext.build_extension(self, ext)
 
 
-if os.name == 'nt':
-  # Must pre-install sentencepice into build directory.
+def get_win_arch():
   arch = 'win32'
   if sys.maxsize > 2**32:
     arch = 'amd64'
   if 'arm' in platform.machine().lower():
     arch = 'arm64'
+  if os.getenv('PYTHON_ARCH', '') == 'ARM64':
+    # Special check for arm64 under ciwheelbuild, see https://github.com/pypa/cibuildwheel/issues/1942
+    arch = 'arm64'
+  return arch
+
+
+if os.name == 'nt':
+  # Must pre-install sentencepice into build directory.
+  arch = get_win_arch()
   if os.path.exists('..\\build\\root_{}\\lib'.format(arch)):
     cflags = ['/std:c++17', '/I..\\build\\root_{}\\include'.format(arch)]
     libs = [


### PR DESCRIPTION
## Why to modify

Recently, I attempted to install sentencepiece using pip on Windows on ARM, but due to `python/setup.py` not taking into account `arm64` in the judgment of Windows arch, cmake mistakenly built the lib for the `AMD64` architecture. 

https://github.com/google/sentencepiece/blob/2de10cb30e982b980125d4713236dd2b29cc5f0c/python/setup.py#L125-L137

## What has been modified

### 1. For building from source or pip install from source

I added a judgment for `arm64` through `platform.machine()`, without modifying the judgment statements for x86 and x64, to ensure that it does not have any side effects on the original architecture building.

At the same time, I have added a section in the Python build documentation that explains how to build from source code on Windows for the convenience of Windows users.

### 2. For building wheels for win-arm64 automatically

I've also modified the `.github/workflows/wheel.yml` to build wheels for win-arm64 automatically. But there's a bug in cibuildwheel. https://github.com/pypa/cibuildwheel/issues/1942#issue-2421737266

Simply put, for the win arm64 arch in cibuildwheel, `platform.machine()` will retrieve `AMD64` instead of `ARM64`. This will cause issues with the judgment of arch in `setup.py`, resulting in selecting the wrong lib path during build. So I add a special check for win-arm under ciwheelbuild using env `PYTHON_ARCH`. 

Here's the Github Actions building results on my own repo. https://github.com/Nagico2/sentencepiece/actions/runs/10105917616

## The outcomes

Now windows on arm users can build and install python wrapper from source. And after the modification of `python/setup.py` have been published to PyPI, windows on arm users can use `pip install sentencepiece` to build and install. 

After the wheels for win-arm published to PyPI, indows on arm users can use `pip install sentencepiece` to install the pre-built wheels. 

## Others

I've also tried to add win-arm build in `cmake.yml`. But there's another bug in setup-python (https://github.com/actions/setup-python/issues/915). So I haven't made any modifications to this yet. 

---------

Modifying the build code may lead to serious consequences, please conduct comprehensive and full testing.

Thank you all for building the Windows on ARM ecosystem. :)