### PR TITLE
Fix CI build issues

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,8 +23,8 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       if: failure() && steps.build.outcome == 'success'
       with:
-        name: artifacts
+        name: artifacts-cifuzz
         path: ./out/artifacts

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,7 +65,19 @@ jobs:
         python -m pip install --require-hashes --no-dependencies -r ../.github/workflows/requirements/base.txt
         python setup.py build
         python setup.py bdist_wheel
-        python -m pytest
+
+    - name: Glob wheel
+      uses: tj-actions/glob@2944188f585a0ec102a6a82d9eeb3aed69785393 # v22.0.1
+      id: wheel
+      with:
+        files: ./python/dist/sentencepiece-*.whl
+
+    - name: Install Python Wrapper
+      run: python3 -m pip install "${{ steps.wheel.outputs.paths }}"
+
+    - name: Test Python Wrapper
+      working-directory: ${{github.workspace}}/python
+      run: python -m pytest
 
     - name: Upload artifacts
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -67,10 +67,10 @@ jobs:
         python setup.py bdist_wheel
         python -m pytest
 
-    - name: Upload artifcacts
-      uses: actions/upload-artifact@v3
+    - name: Upload artifacts
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
-        name: artifcacts
+        name: artifacts-cmake-${{ matrix.os }}-${{ matrix.arch }}
         path: ./build/*.7z
 
     - name: Upload Release Assets

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04, windows-latest, macOS-11 ]
+        os: [ ubuntu-latest, ubuntu-20.04, windows-latest, macOS-latest ]
         arch: [ x64 ]
         include:
           - os: windows-latest
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     permissions:
-      contents: write # svenstaro/upload-release-action 
+      contents: write # svenstaro/upload-release-action
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
         arch: [ x64 ]
         include:
           - os: windows-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, ubuntu-22.04, windows-latest, macOS-latest ]
         arch: [ x64 ]
         include:
           - os: windows-latest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -91,9 +91,9 @@ jobs:
         run: cp -f dist/*.tar.gz wheelhouse/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: artifacts
+          name: artifacts-wheel-${{ matrix.os }}
           path: |
             ./python/wheelhouse/*.whl
             ./python/wheelhouse/*.tar.gz

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -19,12 +19,12 @@ jobs:
       digests-windows: ${{ steps.hash-windows.outputs.digests }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-11]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}
 
     permissions:
-      contents: write # svenstaro/upload-release-action 
+      contents: write # svenstaro/upload-release-action
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/python/test/sentencepiece_test.py
+++ b/python/test/sentencepiece_test.py
@@ -14,15 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.!
-
-import sys
-
-sys.path.insert(0, 'src')
-
 from collections import defaultdict
 import io
 import os
 import pickle
+import sys
 import unittest
 import sentencepiece as spm
 


### PR DESCRIPTION
- `actions/upload-artifact` v3 is EoL and no longer works ( https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ )
- ~There is an ongoing issues with `docker/setup-qemu-action` breaking `aarch64` builds ( https://github.com/pypa/cibuildwheel/discussions/2256 )~
- Python tests were failing due to a circular import, swapped to installing the wheel to resolve.
- Swap out `macOS-11` (deprecated, no longer available: [`macos-11`](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/), [`macos-12`](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/) ) for [`macos-latest`](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) (currently `macos-14`).
- Remove use of `ubuntu-20.04` (deprecated and no longer available: [`ubuntu-20.04`](https://github.com/actions/runner-images/issues/11101)). I think the intention here was to run all ubuntu LTS versions, so I've also added `ubuntu-22.04` (`ubuntu-24.04` is already present as `ubuntu-latest`).

Sample builds can be found here: https://github.com/dbowring/sentencepiece/pull/2 

Would replace #1066.