### PR TITLE
AIX porting changes

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -93,8 +93,12 @@ class build_ext(_build_ext):
     if sys.platform == 'darwin':
       cflags.append('-mmacosx-version-min=10.9')
     else:
-      cflags.append('-Wl,-strip-all')
-      libs.append('-Wl,-strip-all')
+      if sys.platform == 'aix':
+          cflags.append('-Wl,-s')
+          libs.append('-Wl,-s')
+      else:
+          cflags.append('-Wl,-strip-all')
+          libs.append('-Wl,-strip-all')
     if sys.platform == 'linux':
       libs.append('-Wl,-Bsymbolic')
     print('## cflags={}'.format(' '.join(cflags)))

--- a/src/common.h
+++ b/src/common.h
@@ -66,11 +66,15 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 #if defined(_FREEBSD)
 #include <sys/endian.h>
 #endif
-#if !defined(__APPLE__) && !defined(_WIN32) && !defined(_FREEBSD)
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(_FREEBSD) && !defined(_AIX)
 #include <endian.h>
 #if BYTE_ORDER == __BIG_ENDIAN
 #define IS_BIG_ENDIAN
 #endif
+#endif
+
+#if defined(_AIX) && BYTE_ORDER == BIG_ENDIAN
+#define IS_BIG_ENDIAN
 #endif
 
 namespace sentencepiece {


### PR DESCRIPTION
This PR contains two fixes for issues found during porting on AIX OS.

-  Fix for below error to handle the processing of  endian.h . This file is not available in AIX.

```
In file included from /sentencepiece/src/pretokenizer_for_training.h:21,
                 from /sentencepiece/src/pretokenizer_for_training.cc:14:
/sentencepiece/src/common.h:70:10: fatal error: endian.h: No such file or directory
   70 | #include <endian.h>
      |          ^~~~~~~~~~
compilation terminated.
```

- Fix for below AIX linker error while doing python binding installation .
```
ld: 0706-012 The -t flag is not recognized.
ld: 0706-027 The -i flag is ignored.
ld: 0706-012 The -p flag is not recognized.
ld: 0706-012 The -- flag is not recognized.
ld: 0706-012 The -a flag is not recognized.
```





