### PR TITLE
Add missing <cstdint> in sentencepiece_processor.h

### DIFF
--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -15,6 +15,7 @@
 #ifndef SENTENCEPIECE_PROCESSOR_H_
 #define SENTENCEPIECE_PROCESSOR_H_
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Fixes "`uint32_t` does not name a type" gemma.cpp build errors