### PR TITLE
setup.py fix

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -144,7 +144,7 @@ if os.name == 'nt':
       cmake_arch = "ARM64"
     subprocess.check_call([
         'cmake',
-        'sentencepiece',
+        '..',
         '-A',
         cmake_arch,
         '-B',

--- a/python/setup.py
+++ b/python/setup.py
@@ -142,9 +142,12 @@ if os.name == 'nt':
       cmake_arch = 'x64'
     elif arch == "arm64":
       cmake_arch = "ARM64"
+
+    cmake_source_dir = os.path.abspath('..')
+
     subprocess.check_call([
         'cmake',
-        '..',
+        cmake_source_dir,
         '-A',
         cmake_arch,
         '-B',

--- a/python/setup.py
+++ b/python/setup.py
@@ -151,6 +151,7 @@ if os.name == 'nt':
         'build',
         '-DSPM_ENABLE_SHARED=OFF',
         '-DCMAKE_INSTALL_PREFIX=build\\root',
+        '-DCMAKE_POLICY_VERSION_MINIMUM=3.5',
     ])
     subprocess.check_call([
         'cmake',

--- a/python/setup.py
+++ b/python/setup.py
@@ -143,7 +143,7 @@ if os.name == 'nt':
     elif arch == "arm64":
       cmake_arch = "ARM64"
 
-    cmake_source_dir = os.path.abspath('..')
+    cmake_source_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
     subprocess.check_call([
         'cmake',


### PR DESCRIPTION
Trying to fix setup code for two errors when installing the package:

Error 1: cmake_minimum_required compatibility
```
CMake Error at CMakeLists.txt:15 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Error 2: source directory not found
```
CMake Error: The source directory "xxx" does not exist.
```

Only tested on Windows python 3.13. Related issue: #1111 