### PR TITLE
Update README.md: Document required permissions for cloning vcpkg on Unix‐like systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ On OSX/macOS, replace the last command with `sudo update_dyld_shared_cache`
 
 You can download and install sentencepiece using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
+    sudo git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install


### PR DESCRIPTION
Greetings,

Cloning the vcpkg repository into a directory without write permissions results in a “Permission denied” error. This pull request updates the documentation to clarify that users must either run the clone command with elevated privileges (via sudo) or ensure they have write access to the target directory.

Details: Steps to Reproduce:

1. Open a shell in a directory owned by root (or otherwise write-protected for your user).
2. Run:
```
git clone https://github.com/Microsoft/vcpkg.git
cd vcpkg
./bootstrap-vcpkg.sh
./vcpkg integrate install
./vcpkg install sentencepiece
```
3. Observe the error:
```
fatal: could not create work tree dir 'vcpkg': Permission denied
```
Expected behavior: The repository should clone successfully and all subsequent commands should complete without permission.

This issue may be tackled by enforcing ```sudo``` permission:
```
sudo git clone https://github.com/Microsoft/vcpkg.git
cd vcpkg
./bootstrap-vcpkg.sh
./vcpkg integrate install
./vcpkg install sentencepiece
Cloning into 'vcpkg'...
remote: Enumerating objects: 275776, done.
.
.
.
```
Thank you for reviewing this contribution! Please let me know if you’d like any adjustments to the wording or placement of this note.