### PR TITLE
Bump cmake_minimum_required to satisfy CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.!
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 file(STRINGS "VERSION.txt" SPM_VERSION)
 message(STATUS "VERSION: ${SPM_VERSION}")
 


### PR DESCRIPTION
[CMake 4.0 removed compatibility with 3.5 and earlier versions.](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features)
