### PR TITLE
Add support for macOS >= 10.13

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -55,6 +55,7 @@ jobs:
           cmake -B build -DSPM_ENABLE_SHARED=OFF -DSPM_DISABLE_EMBEDDED_DATA=ON -DCMAKE_INSTALL_PREFIX=build/root
           cmake --build build --config Release --target install --parallel 8
         env:
+          MACOSX_DEPLOYMENT_TARGET: 10.13
           CMAKE_OSX_ARCHITECTURES: arm64;x86_64
 
       - name: Install cibuildwheel


### PR DESCRIPTION
This PR adds supports for macOS between 10.13 and 11.

Locally tested to be working on macOS 10.13. No longer show any error on `import sentencepiece`.

Closes #1099.