### PR TITLE
fix: move testpaths under tool.pytest.ini_options section

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,6 +35,8 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
+
+[tool.pytest.ini_options]
 testpaths = ["test"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Summary

Fixes the incorrect placement of testpaths configuration in python/pyproject.toml to comply with pytest standards and enable proper tool compatibility. This PR fixes #1159.

Problem

The testpaths configuration was incorrectly placed under the [project.optional-dependencies] section, which caused:
- pytest not recognizing the test path configuration
- Dependency managers like uv failing to parse the file with errors about unsatisfiable dependencies (sentencepiece[testpaths]'s requirements are unsatisfiable)

Changes

- Created a new [tool.pytest.ini_options] section in python/pyproject.toml
- Moved testpaths = ["test"] from [project.optional-dependencies] to [tool.pytest.ini_options]

Impact

This fix ensures:
- Proper pytest configuration following official pytest documentation
- Compatibility with modern Python dependency managers (e.g. uv)
