### PR TITLE
Fix macOS build: detect correct SDK path and specify C++ stdlib

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -99,6 +99,9 @@ class build_ext(_build_ext):
     # See: https://github.com/neulab/xnmt/issues/199
     if sys.platform == 'darwin':
       cflags.append('-mmacosx-version-min=10.9')
+      # get correct SDK path by xcrun
+      sdk_path = subprocess.check_output(['xcrun', '--show-sdk-path']).decode().strip()
+      libs.extend(['-stdlib=libc++', f'-isysroot{sdk_path}'])
     else:
       if sys.platform == 'aix':
         cflags.append('-Wl,-s')


### PR DESCRIPTION
This pull request fixes a linker error that occurs when building the Python wheel package on macOS Tahoe. The build process previously failed with "ld: library 'c++' not found" error because it attempted to use a hardcoded SDK path that may not exist in the current Xcode installation.

 The fix implements the following changes in `python/setup.py`:
  - detects the correct SDK path using `xcrun --show-sdk-path`
  - Explicitly specifies `-stdlib=libc++` to link against the C++ standard library
  - Adds the detected SDK path via `-isysroot` flag to the linker options

These changes ensure that the build process uses the appropriate SDK and libraries for the installed Xcode version.

Fix #1170.

  **Testing Information:**

  Tested on:
  - macOS 26.1 (Build 25B78)
  - Xcode 26.1.1 (Build 17B100)
  - Python 3.12.6

  Command used:
  ```bash
  uv run python setup.py bdist_wheel
```