### PR TITLE
Add early return when nbest_samples is empty to prevent potential issues

### DIFF
--- a/src/unigram_model.cc
+++ b/src/unigram_model.cc
@@ -791,6 +791,10 @@ NBestEncodeResult Model::SampleEncodeAndScore(absl::string_view normalized,
         nbest_samples.pop_back();
       }
     }
+    if (nbest_samples.empty()) {
+      return results;
+    }
+
     // We use the perturbed score of the k+1th element to calculate the
     // inclusion probability.
     const double kappa = static_cast<double>(nbest_samples.back().second);


### PR DESCRIPTION
Prevents accessing `nbest_samples.back()` when the container is empty, which would cause undefined behavior.

Fixes #1198