### PR TITLE
Clamp UTF-8 length in ConvertToUnicodeSpans

### DIFF
--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -68,7 +68,9 @@ void ConvertToUnicodeSpansInternal(SentencePieceText *spt) {
   size_t prev = 0;
   int ulen = 0;
   while (!str.empty()) {
-    const size_t mblen = std::max<int>(1, string_util::OneCharLen(str.data()));
+    const size_t mblen =
+        std::min(str.size(),
+                 static_cast<size_t>(std::max<int>(1, string_util::OneCharLen(str.data()))));
     for (int i = prev; i < prev + mblen; ++i) {
       utf8_to_unicode[i] = ulen;
     }

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -1707,6 +1707,14 @@ TEST(SentencePieceProcessorTest, ConvertToUnicodeSpansTest) {
     EXPECT_EQ(spt.pieces(2).begin(), 8);
     EXPECT_EQ(spt.pieces(2).end(), 10);
   }
+
+  for (const char lead : {static_cast<char>(0xC2), static_cast<char>(0xE0),
+                          static_cast<char>(0xF0)}) {
+    const auto spt = make_spt({std::string(1, lead)});
+    EXPECT_EQ(spt.pieces_size(), 1);
+    EXPECT_EQ(spt.pieces(0).begin(), 0);
+    EXPECT_EQ(spt.pieces(0).end(), 1);
+  }
 }
 
 }  // namespace sentencepiece


### PR DESCRIPTION
This change fixes an out-of-bounds write in `ConvertToUnicodeSpans()` when processing truncated UTF-8 lead bytes.

  Root cause:
  - `OneCharLen()` infers the UTF-8 length from the lead byte alone.
  - `ConvertToUnicodeSpansInternal()` used that length without clamping it to the remaining input size.
  - For malformed one-byte inputs such as `0xC2`, `0xE0`, and `0xF0`, this could write past the end of `utf8_to_unicode`.

  Fix:
  - Clamp the computed UTF-8 byte length to `str.size()` before using it.

  Tests:
  - Add regression coverage for malformed one-byte inputs:
    - `0xC2`
    - `0xE0`
    - `0xF0`

  Validation:
  - `ctest --test-dir /tmp/spmbuild_test --output-on-failure`