### PR TITLE
fix: add missing absl/log/check.h include for DCHECK macros in internal build

### DIFF
--- a/src/model_interface.h
+++ b/src/model_interface.h
@@ -26,6 +26,7 @@
 #include "sentencepiece_model.pb.h"
 #include "sentencepiece_processor.h"
 #include "third_party/absl/container/flat_hash_map.h"
+#include "third_party/absl/log/check.h"
 #include "third_party/absl/strings/string_view.h"
 #include "third_party/darts_clone/darts.h"
 #include "util.h"


### PR DESCRIPTION
## Describe the change

The `internal` absl provider build has been failing across all architectures (aarch64, arm, powerpc, s390x, riscv64, i686, ...) with:

```
error: 'DCHECK_GE' was not declared in this scope; did you mean 'CHECK_GE'?
error: 'DCHECK_LT' was not declared in this scope; did you mean 'CHECK_LT'?
```

`src/model_interface.h` uses `DCHECK_GE` and `DCHECK_LT` throughout, but does not include the header that defines them. The bundled `third_party/absl/log/check.h` defines `CHECK_*` macros but not `DCHECK_*` — those are provided via a separate Abseil include path that is present in the `module` build but not resolved correctly in the `internal` build.

The fix is a single include: `"third_party/absl/log/check.h"` added alongside the other absl includes already present in the file.

## Link to a related Issue

Visible since at least the April 13 merge of #1207 — the `internal` matrix has been red ever since.

## Testing Information

The `module` build variant passes. The `internal` build fails without this include on every cross-compilation target.