### PR TITLE
Add runtime bounds checks for piece ID accessors

### DIFF
--- a/src/model_interface.h
+++ b/src/model_interface.h
@@ -136,8 +136,10 @@ class ModelInterface {
   // Returns the string representation of vocab with `id`.
   // id must be 0 <= id < GetPieceSize().
   virtual const std::string &IdToPiece(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) {
+      static const std::string kEmpty;
+      return kEmpty;
+    }
     return model_proto_->pieces(id).piece();
   }
 
@@ -152,47 +154,41 @@ class ModelInterface {
   // Score represents a log probability of the piece.
   // We can roughly estimate the unigram frequency of the piece.
   virtual float GetScore(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return 0.0f;
     return model_proto_->pieces(id).score();
   }
 
   // Returns true if `id` is unknown symbol.
   virtual bool IsUnknown(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::UNKNOWN);
   }
 
   // Returns true if `id` is control symbol.
   virtual bool IsControl(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::CONTROL);
   }
 
   // Returns true if `id` is unused symbol.
   virtual bool IsUnused(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::UNUSED);
   }
 
   // Returns true if `id` is user defined symbol.
   virtual bool IsUserDefined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::USER_DEFINED);
   }
 
   // Returns true if `id` is byte symbol.
   virtual bool IsByte(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() == ModelProto::SentencePiece::BYTE);
   }
 
@@ -215,42 +211,36 @@ class ModelInterface {
 
   // Non-virtual (inlined) implementation for faster execution.
   inline float GetScoreInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return 0.0f;
     return model_proto_->pieces(id).score();
   }
 
   inline bool IsUnknownInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::UNKNOWN);
   }
 
   inline bool IsControlInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::CONTROL);
   }
 
   inline bool IsUnusedInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::UNUSED);
   }
 
   inline bool IsUserDefinedInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() ==
             ModelProto::SentencePiece::USER_DEFINED);
   }
 
   inline bool IsByteInlined(int id) const {
-    // DCHECK_GE(id, 0);
-    // DCHECK_LT(id, model_proto_->pieces_size());
+    if (id < 0 || id >= model_proto_->pieces_size()) return false;
     return (model_proto_->pieces(id).type() == ModelProto::SentencePiece::BYTE);
   }
 


### PR DESCRIPTION
## Summary

The 13 piece ID accessor functions in `ModelInterface` (`src/model_interface.h`) had their `DCHECK` bounds checks commented out since commit bd8cf19. Without validation, a crafted `.model` file with a malicious trie can return out-of-range piece IDs, causing **out-of-bounds reads** on the `model_proto_->pieces()` array.

**Affected functions (7 virtual + 6 inlined):**
- `IdToPiece`, `GetScore`, `IsUnknown`, `IsControl`, `IsUnused`, `IsUserDefined`, `IsByte`
- `GetScoreInlined`, `IsUnknownInlined`, `IsControlInlined`, `IsUnusedInlined`, `IsUserDefinedInlined`, `IsByteInlined`

## Fix

Replace the commented-out `DCHECK` macros with runtime bounds checks (`if (id < 0 || id >= model_proto_->pieces_size())`) that return safe defaults for out-of-range IDs:

- `const std::string&` functions: return a static empty string
- `float` functions: return `0.0f`
- `bool` functions: return `false`

This prevents OOB memory access when processing untrusted model files while maintaining the same API behavior for valid inputs.

## Reproduction

Load a crafted `.model` file where the serialized trie contains node IDs exceeding `pieces_size()`. During tokenization, the model's `Encode()` path calls `IdToPiece()` / `GetScore()` / `IsControl()` etc. with the trie-returned IDs, which access `model_proto_->pieces(id)` without bounds checking, reading out-of-bounds memory.