### PR TITLE
Validate darts-clone trie offsets at model load

### DIFF
--- a/src/normalizer.cc
+++ b/src/normalizer.cc
@@ -62,6 +62,11 @@ void Normalizer::Init() {
     // but the number of double array units.
     trie_->set_array(const_cast<char *>(trie_blob.data()),
                      trie_blob.size() / trie_->unit_size());
+    if (!trie_->validate()) {
+      status_ = util::InternalError(
+          "Trie data contains out-of-bounds node references.");
+      return;
+    }
   }
 }
 

--- a/third_party/darts_clone/darts.h
+++ b/third_party/darts_clone/darts.h
@@ -297,6 +297,11 @@ class DoubleArrayImpl {
   inline value_type traverse(const key_type *key, std::size_t &node_pos,
       std::size_t &key_pos, std::size_t length = 0) const;
 
+  // validate() scans the array of units and verifies that every offset
+  // leads to a position within bounds.  Call after set_array() to reject
+  // malformed data before any search is performed.
+  bool validate() const;
+
  private:
   typedef Details::uchar_type uchar_type;
   typedef Details::id_type id_type;
@@ -428,6 +433,24 @@ int DoubleArrayImpl<A, B, T, C>::save(const char *file_name,
   }
   std::fclose(file);
   return 0;
+}
+
+template <typename A, typename B, typename T, typename C>
+bool DoubleArrayImpl<A, B, T, C>::validate() const {
+  if (size_ == 0) {
+    return true;
+  }
+  for (std::size_t i = 0; i < size_; ++i) {
+    const id_type offset = array_[i].offset();
+    if (offset == 0) {
+      continue;
+    }
+    const std::size_t base = i ^ offset;
+    if ((base | 0xFF) >= size_) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template <typename A, typename B, typename T, typename C>


### PR DESCRIPTION
## Summary

Add a `validate()` method to `DoubleArrayImpl` that performs a single O(n) scan
of the trie array at model load, verifying that every offset-derived position
stays within the allocated array.  This catches malformed trie data early
without adding any overhead to the search hot path.

- `darts.h`: add `validate()` that checks `(i ^ offset) | 0xFF < size_` for
  each unit with a non-zero offset
- `normalizer.cc`: call `validate()` after `set_array()`, reject the model if
  the check fails

## Approach

For each unit at position `i` with offset `o`, children are reachable at
`(i ^ o) ^ c` for all byte values `c` in [0, 255].  The maximum of that
expression is `(i ^ o) | 0xFF`.  If that exceeds the array size, the trie
is structurally invalid.

Running the check once during `Normalizer::Init()` is sufficient because the
array is immutable after loading.