### PR TITLE
Fix segfault in SampleEncodeAndScore when wor=true and include_best=true with single-path input

### DIFF
--- a/src/unigram_model.cc
+++ b/src/unigram_model.cc
@@ -793,6 +793,13 @@ NBestEncodeResult Model::SampleEncodeAndScore(absl::string_view normalized,
         nbest_samples.pop_back();
       }
     }
+
+    if (nbest_samples.empty()) {
+      // No additional samples available (e.g. only one unique path exists).
+      // Return the best-path result that was already added above.
+      return results;
+    }
+
     // We use the perturbed score of the k+1th element to calculate the
     // inclusion probability.
     const double kappa = static_cast<double>(nbest_samples.back().second);

--- a/src/unigram_model_test.cc
+++ b/src/unigram_model_test.cc
@@ -612,6 +612,33 @@ TEST(UnigramModelTest, SampleEncodeAndScoreTest) {
   }
 }
 
+TEST(UnigramModelTest, SampleEncodeAndScoreSinglePathTest) {
+  // Regression test for segfault when wor=true and include_best=true on an
+  // input that has only a single unique Viterbi path (issue #1198).
+  ModelProto model_proto = MakeBaseModelProto();
+  // Only one piece matches "A", so there is exactly one segmentation path.
+  AddPiece(&model_proto, "A", 0.0);    // 3
+  AddPiece(&model_proto, "B", 0.0);    // 4
+  AddPiece(&model_proto, "AB", 0.5);   // 5
+
+  Model model(model_proto);
+
+  // "A" can only be segmented as ["A"], a single unique path.
+  // Previously this would segfault; now it should return a result with exactly
+  // the best path and no crash.
+  for (int samples = 1; samples <= 3; ++samples) {
+    NBestEncodeResult result =
+        model.SampleEncodeAndScore("A", 1.0, samples, /*wor=*/true,
+                                   /*include_best=*/true);
+    // Must not crash and must return the best-path result.
+    EXPECT_EQ(1, result.size());
+    EXPECT_EQ(1, result[0].first.size());
+    EXPECT_EQ("A", result[0].first[0].first);
+    // Inclusion probability for a deterministic best path is log(1) == 0.
+    EXPECT_NEAR(0.0, result[0].second, 1e-6);
+  }
+}
+
 TEST_P(UnigramModelTest, PieceToIdTest) {
   ModelProto model_proto = MakeBaseModelProto();
 


### PR DESCRIPTION
In `unigram_model.cc`, `Model::SampleEncodeAndScore` segfaults when called with `wor=true` and `include_best=true` on inputs that produce only one unique Viterbi path (e.g. a single quote with certain models).

The root cause is in the `wor=true` branch: `NBest(samples + 1, ...)` is called to draw one extra sample for computing the Gumbel threshold (kappa), but when the input has only a single unique path, after the best path is removed from `nbest_samples`, the vector becomes empty. The code then unconditionally calls `nbest_samples.back()` on line 798, which is undefined behaviour and crashes.

The fix adds an emptiness check on `nbest_samples` immediately after the best-path removal block. If no additional samples remain, the function returns early with just the best-path result that was already pushed into `results`, mirroring the graceful handling already present in the `include_best=false` path.

Fixes #1198
