### PR TITLE
Validate darts-clone trie offsets at model load (v2)

### DIFF
--- a/src/normalizer.cc
+++ b/src/normalizer.cc
@@ -62,6 +62,12 @@ void Normalizer::Init() {
     // but the number of double array units.
     trie_->set_array(const_cast<char *>(trie_blob.data()),
                      trie_blob.size() / trie_->unit_size());
+
+    if (!trie_->validate()) {
+      status_ = util::InternalError(
+          "Trie data contains out-of-bounds node references.");
+      return;
+    }
   }
 }
 

--- a/third_party/darts_clone/darts.h
+++ b/third_party/darts_clone/darts.h
@@ -297,6 +297,8 @@ class DoubleArrayImpl {
   inline value_type traverse(const key_type *key, std::size_t &node_pos,
       std::size_t &key_pos, std::size_t length = 0) const;
 
+  bool validate() const;
+
  private:
   typedef Details::uchar_type uchar_type;
   typedef Details::id_type id_type;
@@ -428,6 +430,30 @@ int DoubleArrayImpl<A, B, T, C>::save(const char *file_name,
   }
   std::fclose(file);
   return 0;
+}
+
+template <typename A, typename B, typename T, typename C>
+bool DoubleArrayImpl<A, B, T, C>::validate() const {
+  if (size_ == 0) {
+    return true;
+  }
+  for (std::size_t i = 0; i < size_; ++i) {
+    // Leaf/value units store data in the offset field, not child pointers.
+    // label() has MSB set (> 0xFF) for these units. Skip them, matching
+    // the same pattern used in open().
+    if (array_[i].label() > 0xFF) {
+      continue;
+    }
+    const id_type offset = array_[i].offset();
+    if (offset == 0) {
+      continue;
+    }
+    const std::size_t base = i ^ offset;
+    if ((base | 0xFF) >= size_) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template <typename A, typename B, typename T, typename C>


### PR DESCRIPTION
This is a revised version of #1216, fixing the test regression caused by pre-compiled NFKC normalization maps.

**Root cause of the test failure:** Leaf/value units in the darts-clone double array store an integer value in their `unit_` field, not a child pointer. The `offset()` accessor on these units returns meaningless bits extracted from the stored value. The original `validate()` checked every unit's offset indiscriminately, so it rejected valid pre-compiled maps whose leaf values happened to decode to large offsets.

**Fix:** Skip units where `label() > 0xFF` (MSB set), which identifies leaf/value units. This matches the existing pattern already used in `open()` (line 380), where the same guard appears:

```cpp
if (units[i].label() <= 0xFF && units[i].offset() >= size) {
```

**What this PR does:**
- Adds `validate()` to `DoubleArrayImpl` in `third_party/darts_clone/darts.h`
- Calls it in `Normalizer::Init()` after `set_array()` to reject corrupted model files
- Correctly skips leaf/value units, preventing false positives on pre-compiled maps

The `GetPrecompiledCharsMapTest` test case now passes because leaf units in the NFKC maps are no longer misinterpreted as having out-of-bounds child pointers.