### PR TITLE
Clamp UTF-8 length in ConvertToUnicodeAlignment

### DIFF
--- a/src/sentencepiece_trainer.cc
+++ b/src/sentencepiece_trainer.cc
@@ -373,8 +373,10 @@ void ConvertToUnicodeAlignment(absl::string_view orig, absl::string_view norm,
     size_t prev = 0;
     int ulen = 0;
     while (!str.empty()) {
-      const size_t mblen =
-          std::max<int>(1, string_util::OneCharLen(str.data()));
+      const size_t mblen = std::min(
+          str.size(),
+          static_cast<size_t>(
+              std::max<int>(1, string_util::OneCharLen(str.data()))));
       for (int i = prev; i < prev + mblen; ++i) {
         utf8_to_unicode[i] = ulen;
       }

--- a/src/sentencepiece_trainer_test.cc
+++ b/src/sentencepiece_trainer_test.cc
@@ -391,6 +391,17 @@ TEST(SentencePieceTrainerTest, NormalizationTest) {
     EXPECT_EQ(normalized, "▁ガイダンス");
     ConvertToUnicodeAlignment(kInput, normalized, &offsets);
     EXPECT_EQ(offsets, std::vector<size_t>({0, 0, 2, 3, 5, 6, 7}));
+
+    // Regression: truncated UTF-8 lead bytes (e.g. a single 0xF0 announces a
+    // 4-byte sequence but supplies only 1) must not cause out-of-bounds writes
+    // inside the utf8_to_unicode_offsets lambda.
+    for (const char lead : {static_cast<char>(0xC2), static_cast<char>(0xE0),
+                            static_cast<char>(0xF0)}) {
+      const std::string truncated(1, lead);
+      std::vector<size_t> trunc_offsets = {0};
+      ConvertToUnicodeAlignment(truncated, truncated, &trunc_offsets);
+      EXPECT_EQ(trunc_offsets, std::vector<size_t>({0, 0}));
+    }
   }
 
   auto set_normalization_only = [](SentencePieceNormalizer *normalizer) {


### PR DESCRIPTION
# Clamp UTF-8 length in ConvertToUnicodeAlignment

Fixes https://github.com/google/sentencepiece/issues/1230

## Description
This PR fixes a heap out-of-bounds write vulnerability in `ConvertToUnicodeAlignment` (`src/sentencepiece_trainer.cc`).

When processing malformed or truncated UTF-8 input strings (e.g., a single `0xF0` byte), the loop relies on `string_util::OneCharLen(str.data())` to determine the multi-byte sequence length (`mblen`). Since `OneCharLen` only inspects the lead byte and does not validate against the actual remaining string length, a truncated sequence results in an `mblen` that exceeds `str.size()`.

This causes two issues:
1. The inner loop writes out-of-bounds into the `utf8_to_unicode` heap-allocated `std::vector`.
2. `str.remove_prefix(mblen)` underflows the `absl::string_view`'s size, leading to unbounded reads/writes in subsequent loop iterations.

### The Fix
This PR mirrors the identical fix applied in commit `d14bab4` for the sibling function `ConvertToUnicodeSpansInternal`. We wrap the existing `std::max` logic with a clamp against `str.size()`:

```cpp
const size_t mblen = std::min(
    str.size(),
    static_cast<size_t>(
        std::max<int>(1, string_util::OneCharLen(str.data()))));
```

## Testing
- Added regression tests in `src/sentencepiece_trainer_test.cc` that specifically test 2-byte, 3-byte, and 4-byte truncated UTF-8 sequences as single-byte inputs.
- Built and tested with AddressSanitizer (`-fsanitize=address`) — confirmed that ASan catches the heap-buffer-overflow on the unpatched code, and passes successfully with this PR.
