### PR TITLE
avoid injecting -fPIC and other unix flags on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ endif()
 
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 
-if (SPM_ENABLE_SHARED)
+if (SPM_ENABLE_SHARED AND NOT WIN32)
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif() 
+endif()
 
 # Includes processor name to avoid conflicts.
 set(CPACK_PACKAGE_FILE_NAME

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if (SPM_PROTOBUF_PROVIDER STREQUAL "internal")
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream_impl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream_impl_lite.cc)
-  if (MSVC)
+  if (WIN32)
     add_definitions("/DHAVE_PTHREAD /wd4018 /wd4514")
   else()
     add_definitions("-pthread -DHAVE_PTHREAD=1 -Wno-sign-compare -Wno-deprecated-declarations")
@@ -251,7 +251,7 @@ endif()
 set_target_properties(sentencepiece-static PROPERTIES OUTPUT_NAME "sentencepiece")
 set_target_properties(sentencepiece_train-static PROPERTIES OUTPUT_NAME "sentencepiece_train")
 
-if (NOT MSVC)
+if (NOT WIN32)
   set(CMAKE_CXX_FLAGS "-O3 -Wall -fPIC ${CMAKE_CXX_FLAGS}")
   set_source_files_properties(
     sentencepiece.pb.cc sentencepiece_model.pb.cc


### PR DESCRIPTION

### Describe the change

Several Unix-toolchain compiler flags were gated on `NOT MSVC`, which is
`FALSE` for `clang.exe` on Windows (whether invoked as `clang-cl` or as
`clang` driven by a toolchain file targeting the MSVC ABI). As a result,
native-Clang Windows builds failed on flags such as `-fPIC` and `-pthread`,
which are rejected on the MSVC ABI.

This PR switches the gates from `NOT MSVC` to `NOT WIN32` at the three
sites where Unix-style flags are injected:

- `CMakeLists.txt` — gate `CMAKE_POSITION_INDEPENDENT_CODE ON` on
  `SPM_ENABLE_SHARED AND NOT WIN32`. The existing
  `if(WIN32) set(SPM_ENABLE_SHARED OFF)` block already encodes the intent
  that PIC is not relevant on Windows; this just closes an ordering gap
  (the PIC global was being set before `SPM_ENABLE_SHARED` got forced off).
- `src/CMakeLists.txt` (≈ L254) — change `if (NOT MSVC)` to `if (NOT WIN32)`
  for the `-O3 -Wall -fPIC` / `-Wno-*` / `-DPIC` block.
- `src/CMakeLists.txt` (internal-protobuf branch, ≈ L56–60) — change
  `if (MSVC) ... else()` to `if (WIN32) ... else()` for the `-pthread
  -DHAVE_PTHREAD=1 -Wno-*` block.

The Windows ABI is position-independent by definition, so `-fPIC` is a
no-op there even for MSVC. Gating on the platform rather than on the
compiler frontend matches the intent of these flags (they are
Unix-toolchain shorthand) and unblocks Clang-on-Windows builds.

Same root cause across all three sites, so kept as a single atomic commit.

### Link to a related Issue

Fixes #1239

### Testing Information

Verified on Windows with Clang configured for the MSVC ABI (toolchain
file selecting `clang.exe` with `CMAKE_CXX_COMPILER_TARGET` set to a
`*-pc-windows-msvc` triple):

- Without this change, the build fails with Clang rejecting `-fPIC`.
- With this change, configure and build succeed, and `-fPIC`,
  `-pthread`, `-O3`, `-Wall`, and the `-Wno-*` flags are absent from
  the compile command lines.

The affected blocks are gated on the platform rather than on the
compiler, so behavior on Linux/macOS and on Windows / MSVC `cl.exe` is
unchanged by inspection: `NOT WIN32` is equivalent to the old
`NOT MSVC` on those platforms (and the PIC global was already a no-op
on MSVC).

No new tests are added because this is a build-system-only change.
