### PR TITLE
Update Dockerfile since #1174

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.23 AS build
 
 RUN apk add --no-cache \
+    linux-headers \
+    git \
     cmake \
     make \
     g++ \


### PR DESCRIPTION
This PR is a continuation of #1174.

The docker build has been broken since 686eaac42a67b4bbe8b773817d26798612bbb8ca. The build errors reported at a899e9a247791163095a331d8f16e4b7ea2068a0 are:

1. `error: could not find git for clone of abseil-cpp-populate`
2. `/workspace/third_party/abseil-cpp/absl/base/internal/spinlock_linux.inc:17:10: fatal error: linux/futex.h: No such file or directory`

Therefore, this commit fixes them by:

1. Add `git` to build dependency.
2. Add `linux-headers` to build dependency.