### PR TITLE
fix: use cl.exe-style flags only when the compiler is cl.exe

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,11 @@ if (SPM_PROTOBUF_PROVIDER STREQUAL "internal")
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream_impl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/protobuf-lite/zero_copy_stream_impl_lite.cc)
-  if (WIN32)
+  if (MSVC)
     add_definitions("/DHAVE_PTHREAD /wd4018 /wd4514")
+  elseif (WIN32)
+    # Windows but not cl.exe (e.g. Clang targeting *-pc-windows-msvc, MinGW).
+    add_definitions("-DHAVE_PTHREAD=1 -Wno-sign-compare -Wno-deprecated-declarations")
   else()
     add_definitions("-pthread -DHAVE_PTHREAD=1 -Wno-sign-compare -Wno-deprecated-declarations")
   endif()


### PR DESCRIPTION

### Describe the change

In `src/CMakeLists.txt`, the bundled-protobuf branch
(`if (SPM_PROTOBUF_PROVIDER STREQUAL "internal")`, the default) selects
compiler flags with a two-way `if (WIN32) ... else()` split. The `WIN32`
branch emits cl.exe-only syntax (`/DHAVE_PTHREAD /wd4018 /wd4514`), but
`WIN32` is true for any Windows toolchain, including Clang invoked via
its GNU-style driver and MinGW. With those drivers, slash-prefixed
tokens are treated as input file paths, so the build fails with
`clang++: error: no such file or directory: '/DHAVE_PTHREAD'`.
`clang-cl.exe` is unaffected because CMake reports `MSVC=TRUE` for it.

This PR splits the two-way branch into a three-way branch keyed on the
compiler rather than the OS:

```cmake
if (MSVC)
  add_definitions("/DHAVE_PTHREAD /wd4018 /wd4514")
elseif (WIN32)
  # Windows but not cl.exe (e.g. Clang targeting *-pc-windows-msvc, MinGW).
  add_definitions("-DHAVE_PTHREAD=1 -Wno-sign-compare -Wno-deprecated-declarations")
else()
  add_definitions("-pthread -DHAVE_PTHREAD=1 -Wno-sign-compare -Wno-deprecated-declarations")
endif()
```

- `MSVC` branch: same flags as before, applied to `cl.exe` and
  `clang-cl.exe`.
- New `WIN32` branch: GNU-style flags for Windows non-cl.exe drivers,
  without `-pthread` (which has no meaning on Windows).
- `else` branch: unchanged.

No flag changes for any toolchain that compiled successfully before; the
formerly-broken Windows-non-MSVC configurations now compile.

| Toolchain | `MSVC` | `WIN32` | Branch (before) | Branch (after) | Flag change |
|---|:-:|:-:|---|---|---|
| Windows + cl.exe | ✓ | ✓ | `WIN32` | `MSVC` | none |
| Windows + clang-cl.exe | ✓ | ✓ | `WIN32` | `MSVC` | none |
| Windows + Clang (GNU-style driver) | ✗ | ✓ | `WIN32` (broken) | new `WIN32` branch | formerly broken |
| Windows + MinGW | ✗ | ✓ | `WIN32` (broken) | new `WIN32` branch | formerly broken |
| Linux GCC/Clang | ✗ | ✗ | `else` | `else` | none |
| macOS Clang | ✗ | ✗ | `else` | `else` | none |

### Link to a related Issue

Fixes #1246

### Testing Information

Verified on Windows with Clang configured for the MSVC ABI via the
GNU-style driver (toolchain file selecting `clang.exe` /
`clang++.exe` with `CMAKE_CXX_COMPILER_TARGET` set to a
`*-pc-windows-msvc` triple), `SPM_PROTOBUF_PROVIDER=internal` (default):

- Without this change, the build fails with
  `clang++: error: no such file or directory: '/DHAVE_PTHREAD'`
  (and `/wd4018`, `/wd4514`) when compiling the bundled
  `protobuf-lite` translation units.
- With this change, those translation units and the rest of the
  `sentencepiece-static` target compile cleanly. The compile commands
  no longer contain the slash-prefixed cl.exe tokens.

No new tests are added because this is a build-system-only change.
