### PR TITLE
Release GIL while executing C++ API

### DIFF
--- a/python/src/sentencepiece/sentencepiece.i
+++ b/python/src/sentencepiece/sentencepiece.i
@@ -81,9 +81,30 @@ int ToSwigError(sentencepiece::util::StatusCode code) {
   return SWIG_RuntimeError;
 }
 
+// RAII class to release GIL.
+// Release GIL in contractor and acquire GIL in destractor.
+class ScopedGILRelease {
+public:
+  ScopedGILRelease() { save_ = PyEval_SaveThread(); }
+  ~ScopedGILRelease() { PyEval_RestoreThread(save_); }
+private:
+  PyThreadState *save_;
+};
+
+// RAII class to aquire GIL.
+// Acquire GIL in contractor and release GIL in destractor.
+class ScopedGILAcquire {
+public:
+  ScopedGILAcquire() { state_ = PyGILState_Ensure(); }
+  ~ScopedGILAcquire() { PyGILState_Release(state_); }
+private:
+  PyGILState_STATE state_;
+};
+
 class PySentenceIterator : public sentencepiece::SentenceIterator {
   public:
   PySentenceIterator(PyObject *iter) : iter_(iter) {
+    ScopedGILAcquire aquire;
     item_ = PyIter_Next(iter_);
     CopyValue();
   }
@@ -97,6 +118,7 @@ class PySentenceIterator : public sentencepiece::SentenceIterator {
   }
 
   void Next() override {
+    ScopedGILAcquire aquire;
     item_ = PyIter_Next(iter_);
     CopyValue();
   }
@@ -294,7 +316,10 @@ inline void InitNumThreads(const std::vector<T> &ins, int *num_threads) {
 
 %exception {
   try {
-    $action
+    {
+      ScopedGILRelease release;
+      $action
+    }
     ReleaseResultObject(resultobj);
   }
   catch (const sentencepiece::util::Status &status) {
@@ -355,6 +380,7 @@ inline void InitNumThreads(const std::vector<T> &ins, int *num_threads) {
 
 %ignore sentencepiece::SentencePieceProcessor::model_proto;
 %ignore sentencepiece::SentencePieceProcessor::mutable_normalizer_spec;
+%ignore sentencepiece::SentencePieceProcessor::SafeIdToPiece;
 %ignore sentencepiece::SentencePieceProcessor::Load;
 %ignore sentencepiece::SentencePieceProcessor::LoadOrDie;
 %ignore sentencepiece::SentencePieceProcessor::SetModel;

--- a/python/src/sentencepiece/sentencepiece.i
+++ b/python/src/sentencepiece/sentencepiece.i
@@ -81,6 +81,7 @@ int ToSwigError(sentencepiece::util::StatusCode code) {
   return SWIG_RuntimeError;
 }
 
+#ifndef Py_GIL_DISABLED
 // RAII class to release GIL.
 // Release GIL in contractor and acquire GIL in destractor.
 class ScopedGILRelease {
@@ -100,6 +101,19 @@ public:
 private:
   PyGILState_STATE state_;
 };
+#else
+class ScopedGILRelease {
+public:
+  ScopedGILRelease() {}
+  ~ScopedGILRelease() {}
+};
+
+class ScopedGILAcquire {
+public:
+  ScopedGILAcquire() {}
+  ~ScopedGILAcquire() {}
+};
+#endif  // Py_GIL_DISABLED
 
 class PySentenceIterator : public sentencepiece::SentenceIterator {
   public:

--- a/python/src/sentencepiece/sentencepiece_wrap.cxx
+++ b/python/src/sentencepiece/sentencepiece_wrap.cxx
@@ -3683,6 +3683,7 @@ int ToSwigError(sentencepiece::util::StatusCode code) {
   return SWIG_RuntimeError;
 }
 
+#ifndef Py_GIL_DISABLED
 // RAII class to release GIL.
 // Release GIL in contractor and acquire GIL in destractor.
 class ScopedGILRelease {
@@ -3702,6 +3703,19 @@ public:
 private:
   PyGILState_STATE state_;
 };
+#else
+class ScopedGILRelease {
+public:
+  ScopedGILRelease() {}
+  ~ScopedGILRelease() {}
+};
+
+class ScopedGILAcquire {
+public:
+  ScopedGILAcquire() {}
+  ~ScopedGILAcquire() {}
+};
+#endif  // Py_GIL_DISABLED
 
 class PySentenceIterator : public sentencepiece::SentenceIterator {
   public:

--- a/python/src/sentencepiece/sentencepiece_wrap.cxx
+++ b/python/src/sentencepiece/sentencepiece_wrap.cxx
@@ -3683,9 +3683,30 @@ int ToSwigError(sentencepiece::util::StatusCode code) {
   return SWIG_RuntimeError;
 }
 
+// RAII class to release GIL.
+// Release GIL in contractor and acquire GIL in destractor.
+class ScopedGILRelease {
+public:
+  ScopedGILRelease() { save_ = PyEval_SaveThread(); }
+  ~ScopedGILRelease() { PyEval_RestoreThread(save_); }
+private:
+  PyThreadState *save_;
+};
+
+// RAII class to aquire GIL.
+// Acquire GIL in contractor and release GIL in destractor.
+class ScopedGILAcquire {
+public:
+  ScopedGILAcquire() { state_ = PyGILState_Ensure(); }
+  ~ScopedGILAcquire() { PyGILState_Release(state_); }
+private:
+  PyGILState_STATE state_;
+};
+
 class PySentenceIterator : public sentencepiece::SentenceIterator {
   public:
   PySentenceIterator(PyObject *iter) : iter_(iter) {
+    ScopedGILAcquire aquire;
     item_ = PyIter_Next(iter_);
     CopyValue();
   }
@@ -3699,6 +3720,7 @@ class PySentenceIterator : public sentencepiece::SentenceIterator {
   }
 
   void Next() override {
+    ScopedGILAcquire aquire;
     item_ = PyIter_Next(iter_);
     CopyValue();
   }
@@ -4638,7 +4660,10 @@ SWIGINTERN PyObject *_wrap_new_ImmutableSentencePieceText_ImmutableSentencePiece
   if (!SWIG_Python_UnpackTuple(args, "new_ImmutableSentencePieceText_ImmutableSentencePiece", 0, 0, 0)) SWIG_fail;
   {
     try {
-      result = (sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece *)new sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece();
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece *)new sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4669,7 +4694,10 @@ SWIGINTERN PyObject *_wrap_delete_ImmutableSentencePieceText_ImmutableSentencePi
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      delete arg1;
+      {
+        ScopedGILRelease release;
+        delete arg1;
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4701,7 +4729,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__pi
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = (std::string *) &((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->piece();
+      {
+        ScopedGILRelease release;
+        result = (std::string *) &((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->piece();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4736,7 +4767,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__su
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = (std::string *) &((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->surface();
+      {
+        ScopedGILRelease release;
+        result = (std::string *) &((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->surface();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4771,7 +4805,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__id
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->id();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->id();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4803,7 +4840,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__be
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->begin();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->begin();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4835,7 +4875,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__en
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->end();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1)->end();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4867,7 +4910,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__su
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText_ImmutableSentencePiece__surface_as_bytes((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1);
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText_ImmutableSentencePiece__surface_as_bytes((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4901,7 +4947,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_ImmutableSentencePiece__pi
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece * >(argp1);
   {
     try {
-      result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText_ImmutableSentencePiece__piece_as_bytes((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1);
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText_ImmutableSentencePiece__piece_as_bytes((sentencepiece::ImmutableSentencePieceText_ImmutableSentencePiece const *)arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4936,7 +4985,10 @@ SWIGINTERN PyObject *_wrap_new_ImmutableSentencePieceText(PyObject *self, PyObje
   if (!SWIG_Python_UnpackTuple(args, "new_ImmutableSentencePieceText", 0, 0, 0)) SWIG_fail;
   {
     try {
-      result = (sentencepiece::ImmutableSentencePieceText *)new sentencepiece::ImmutableSentencePieceText();
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::ImmutableSentencePieceText *)new sentencepiece::ImmutableSentencePieceText();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4967,7 +5019,10 @@ SWIGINTERN PyObject *_wrap_delete_ImmutableSentencePieceText(PyObject *self, PyO
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      delete arg1;
+      {
+        ScopedGILRelease release;
+        delete arg1;
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -4999,7 +5054,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText__pieces_size(PyObject *sel
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->pieces_size();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->pieces_size();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5038,7 +5096,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText__pieces(PyObject *self, Py
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->pieces(arg2);
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->pieces(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5070,7 +5131,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText__text(PyObject *self, PyOb
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      result = (std::string *) &((sentencepiece::ImmutableSentencePieceText const *)arg1)->text();
+      {
+        ScopedGILRelease release;
+        result = (std::string *) &((sentencepiece::ImmutableSentencePieceText const *)arg1)->text();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5105,7 +5169,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText__score(PyObject *self, PyO
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      result = (float)((sentencepiece::ImmutableSentencePieceText const *)arg1)->score();
+      {
+        ScopedGILRelease release;
+        result = (float)((sentencepiece::ImmutableSentencePieceText const *)arg1)->score();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5137,7 +5204,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText_SerializeAsString(PyObject
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->SerializeAsString();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableSentencePieceText const *)arg1)->SerializeAsString();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5171,7 +5241,10 @@ SWIGINTERN PyObject *_wrap_ImmutableSentencePieceText__text_as_bytes(PyObject *s
   arg1 = reinterpret_cast< sentencepiece::ImmutableSentencePieceText * >(argp1);
   {
     try {
-      result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText__text_as_bytes((sentencepiece::ImmutableSentencePieceText const *)arg1);
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::util::bytes *) &sentencepiece_ImmutableSentencePieceText__text_as_bytes((sentencepiece::ImmutableSentencePieceText const *)arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5206,7 +5279,10 @@ SWIGINTERN PyObject *_wrap_new_ImmutableNBestSentencePieceText(PyObject *self, P
   if (!SWIG_Python_UnpackTuple(args, "new_ImmutableNBestSentencePieceText", 0, 0, 0)) SWIG_fail;
   {
     try {
-      result = (sentencepiece::ImmutableNBestSentencePieceText *)new sentencepiece::ImmutableNBestSentencePieceText();
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::ImmutableNBestSentencePieceText *)new sentencepiece::ImmutableNBestSentencePieceText();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5237,7 +5313,10 @@ SWIGINTERN PyObject *_wrap_delete_ImmutableNBestSentencePieceText(PyObject *self
   arg1 = reinterpret_cast< sentencepiece::ImmutableNBestSentencePieceText * >(argp1);
   {
     try {
-      delete arg1;
+      {
+        ScopedGILRelease release;
+        delete arg1;
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5269,7 +5348,10 @@ SWIGINTERN PyObject *_wrap_ImmutableNBestSentencePieceText__nbests_size(PyObject
   arg1 = reinterpret_cast< sentencepiece::ImmutableNBestSentencePieceText * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->nbests_size();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->nbests_size();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5308,7 +5390,10 @@ SWIGINTERN PyObject *_wrap_ImmutableNBestSentencePieceText__nbests(PyObject *sel
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->nbests(arg2);
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->nbests(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5340,7 +5425,10 @@ SWIGINTERN PyObject *_wrap_ImmutableNBestSentencePieceText_SerializeAsString(PyO
   arg1 = reinterpret_cast< sentencepiece::ImmutableNBestSentencePieceText * >(argp1);
   {
     try {
-      result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->SerializeAsString();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::ImmutableNBestSentencePieceText const *)arg1)->SerializeAsString();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5375,7 +5463,10 @@ SWIGINTERN PyObject *_wrap_new_SentencePieceProcessor(PyObject *self, PyObject *
   if (!SWIG_Python_UnpackTuple(args, "new_SentencePieceProcessor", 0, 0, 0)) SWIG_fail;
   {
     try {
-      result = (sentencepiece::SentencePieceProcessor *)new sentencepiece::SentencePieceProcessor();
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::SentencePieceProcessor *)new sentencepiece::SentencePieceProcessor();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5406,7 +5497,10 @@ SWIGINTERN PyObject *_wrap_delete_SentencePieceProcessor(PyObject *self, PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      delete arg1;
+      {
+        ScopedGILRelease release;
+        delete arg1;
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5447,7 +5541,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_LoadFromSerializedProto(PyObje
   }
   {
     try {
-      result = (arg1)->LoadFromSerializedProto(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->LoadFromSerializedProto(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5493,7 +5590,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SetEncodeExtraOptions(PyObject
   }
   {
     try {
-      result = (arg1)->SetEncodeExtraOptions(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->SetEncodeExtraOptions(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5539,7 +5639,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SetDecodeExtraOptions(PyObject
   }
   {
     try {
-      result = (arg1)->SetDecodeExtraOptions(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->SetDecodeExtraOptions(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5597,7 +5700,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_SetVocabulary(PyObject *self, 
   }
   {
     try {
-      result = (arg1)->SetVocabulary((std::vector< absl::string_view > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = (arg1)->SetVocabulary((std::vector< absl::string_view > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5640,7 +5746,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_ResetVocabulary(PyObject *self
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (arg1)->ResetVocabulary();
+      {
+        ScopedGILRelease release;
+        result = (arg1)->ResetVocabulary();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5694,7 +5803,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_LoadVocabulary(PyObject *self,
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = (arg1)->LoadVocabulary(SWIG_STD_MOVE(arg2),arg3);
+      {
+        ScopedGILRelease release;
+        result = (arg1)->LoadVocabulary(SWIG_STD_MOVE(arg2),arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5755,7 +5867,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_CalculateEntropy__SWIG_0(PyObj
   arg4 = reinterpret_cast< float * >(argp4);
   {
     try {
-      result = ((sentencepiece::SentencePieceProcessor const *)arg1)->CalculateEntropy(SWIG_STD_MOVE(arg2),arg3,arg4);
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::SentencePieceProcessor const *)arg1)->CalculateEntropy(SWIG_STD_MOVE(arg2),arg3,arg4);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5808,7 +5923,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_CalculateEntropy__SWIG_1(PyObj
   arg3 = static_cast< float >(val3);
   {
     try {
-      result = (float)((sentencepiece::SentencePieceProcessor const *)arg1)->CalculateEntropy(SWIG_STD_MOVE(arg2),arg3);
+      {
+        ScopedGILRelease release;
+        result = (float)((sentencepiece::SentencePieceProcessor const *)arg1)->CalculateEntropy(SWIG_STD_MOVE(arg2),arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5901,7 +6019,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_GetPieceSize(PyObject *self, P
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->GetPieceSize();
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->GetPieceSize();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5942,7 +6063,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_PieceToId(PyObject *self, PyOb
   }
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->PieceToId(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->PieceToId(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -5981,7 +6105,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_IdToPiece(PyObject *self, PyOb
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (std::string *) &((sentencepiece::SentencePieceProcessor const *)arg1)->IdToPiece(arg2);
+      {
+        ScopedGILRelease release;
+        result = (std::string *) &((sentencepiece::SentencePieceProcessor const *)arg1)->IdToPiece(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6023,7 +6150,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_GetScore(PyObject *self, PyObj
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (float)((sentencepiece::SentencePieceProcessor const *)arg1)->GetScore(arg2);
+      {
+        ScopedGILRelease release;
+        result = (float)((sentencepiece::SentencePieceProcessor const *)arg1)->GetScore(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6062,7 +6192,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_IsUnknown(PyObject *self, PyOb
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsUnknown(arg2);
+      {
+        ScopedGILRelease release;
+        result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsUnknown(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6101,7 +6234,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_IsControl(PyObject *self, PyOb
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsControl(arg2);
+      {
+        ScopedGILRelease release;
+        result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsControl(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6140,7 +6276,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_IsUnused(PyObject *self, PyObj
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsUnused(arg2);
+      {
+        ScopedGILRelease release;
+        result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsUnused(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6179,7 +6318,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_IsByte(PyObject *self, PyObjec
   arg2 = static_cast< int >(val2);
   {
     try {
-      result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsByte(arg2);
+      {
+        ScopedGILRelease release;
+        result = (bool)((sentencepiece::SentencePieceProcessor const *)arg1)->IsByte(arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6211,7 +6353,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_unk_id(PyObject *self, PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->unk_id();
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->unk_id();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6243,7 +6388,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_bos_id(PyObject *self, PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->bos_id();
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->bos_id();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6275,7 +6423,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_eos_id(PyObject *self, PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->eos_id();
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->eos_id();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6307,7 +6458,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_pad_id(PyObject *self, PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->pad_id();
+      {
+        ScopedGILRelease release;
+        result = (int)((sentencepiece::SentencePieceProcessor const *)arg1)->pad_id();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6339,7 +6493,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_serialized_model_proto(PyObjec
   arg1 = reinterpret_cast< sentencepiece::SentencePieceProcessor * >(argp1);
   {
     try {
-      result = ((sentencepiece::SentencePieceProcessor const *)arg1)->serialized_model_proto();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::SentencePieceProcessor const *)arg1)->serialized_model_proto();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6382,7 +6539,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor_LoadFromFile(PyObject *self, P
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor_LoadFromFile(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor_LoadFromFile(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6484,7 +6644,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsIds(PyObject *self, P
   arg9 = static_cast< bool >(val9);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6586,7 +6749,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsPieces(PyObject *self
   arg9 = static_cast< bool >(val9);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6689,7 +6855,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsSerializedProto(PyObj
   arg9 = static_cast< bool >(val9);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6788,7 +6957,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsImmutableProto(PyObje
   arg9 = static_cast< bool >(val9);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -6905,7 +7077,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsIdsBatch(PyObject *se
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsIdsBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsIdsBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7037,7 +7212,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsPiecesBatch(PyObject 
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsPiecesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsPiecesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7170,7 +7348,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsSerializedProtoBatch(
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7298,7 +7479,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__EncodeAsImmutableProtoBatch(P
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__EncodeAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__EncodeAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7362,7 +7546,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIds(PyObject *self, PyO
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIds((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIds((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7423,7 +7610,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsBytes(PyObject *se
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsBytes((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsBytes((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7484,7 +7674,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePieces(PyObject *self, 
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePieces((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePieces((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7545,7 +7738,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsSerializedProto(Py
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7606,7 +7802,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePiecesAsSerializedProto
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePiecesAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePiecesAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7666,7 +7865,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsImmutableProto(PyO
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< int > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7725,7 +7927,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePiecesAsImmutableProto(
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePiecesAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePiecesAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< absl::string_view > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7801,7 +8006,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsBatch(PyObject *self
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7883,7 +8091,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsBytesBatch(PyObjec
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsBytesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsBytesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -7964,7 +8175,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsSerializedProtoBat
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8045,7 +8259,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodeIdsAsImmutableProtoBatc
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodeIdsAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodeIdsAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< int > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8128,7 +8345,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePiecesBatch(PyObject *s
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePiecesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePiecesBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8205,7 +8425,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePiecesAsSerializedProto
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePiecesAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePiecesAsSerializedProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8281,7 +8504,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__DecodePiecesAsImmutableProtoB
   arg3 = static_cast< int >(val3);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__DecodePiecesAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__DecodePiecesAsImmutableProtoBatch((sentencepiece::SentencePieceProcessor const *)arg1,(std::vector< std::vector< absl::string_view > > const &)*arg2,arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8368,7 +8594,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__NBestEncodeAsIds(PyObject *se
   arg7 = static_cast< bool >(val7);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__NBestEncodeAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__NBestEncodeAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8458,7 +8687,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__NBestEncodeAsPieces(PyObject 
   arg7 = static_cast< bool >(val7);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__NBestEncodeAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__NBestEncodeAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8549,7 +8781,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__NBestEncodeAsSerializedProto(
   arg7 = static_cast< bool >(val7);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__NBestEncodeAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__NBestEncodeAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8632,7 +8867,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__NBestEncodeAsImmutableProto(P
   arg7 = static_cast< bool >(val7);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__NBestEncodeAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__NBestEncodeAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8737,7 +8975,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__SampleEncodeAndScoreAsIds(PyO
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsIds((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8851,7 +9092,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__SampleEncodeAndScoreAsPieces(
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsPieces((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -8966,7 +9210,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__SampleEncodeAndScoreAsSeriali
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsSerializedProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9073,7 +9320,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__SampleEncodeAndScoreAsImmutab
   arg10 = static_cast< bool >(val10);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__SampleEncodeAndScoreAsImmutableProto((sentencepiece::SentencePieceProcessor const *)arg1,SWIG_STD_MOVE(arg2),arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9114,7 +9364,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__Normalize(PyObject *self, PyO
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__Normalize(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__Normalize(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9158,7 +9411,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__NormalizeWithOffsets(PyObject
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__NormalizeWithOffsets(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__NormalizeWithOffsets(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9217,7 +9473,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__CalculateEntropy(PyObject *se
   arg3 = static_cast< float >(val3);
   {
     try {
-      result = (float)sentencepiece_SentencePieceProcessor__CalculateEntropy(arg1,SWIG_STD_MOVE(arg2),arg3);
+      {
+        ScopedGILRelease release;
+        result = (float)sentencepiece_SentencePieceProcessor__CalculateEntropy(arg1,SWIG_STD_MOVE(arg2),arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9286,7 +9545,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__CalculateEntropyBatch(PyObjec
   arg4 = static_cast< int >(val4);
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__CalculateEntropyBatch(arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__CalculateEntropyBatch(arg1,(std::vector< absl::string_view > const &)*arg2,arg3,arg4);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9353,7 +9615,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceProcessor__OverrideNormalizerSpec(PyObje
   }
   {
     try {
-      result = sentencepiece_SentencePieceProcessor__OverrideNormalizerSpec(arg1,(std::unordered_map< std::string,std::string > const &)*arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceProcessor__OverrideNormalizerSpec(arg1,(std::unordered_map< std::string,std::string > const &)*arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9406,7 +9671,10 @@ SWIGINTERN PyObject *_wrap_SetRandomGeneratorSeed(PyObject *self, PyObject *args
   arg1 = static_cast< unsigned int >(val1);
   {
     try {
-      sentencepiece::SetRandomGeneratorSeed(arg1);
+      {
+        ScopedGILRelease release;
+        sentencepiece::SetRandomGeneratorSeed(arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9437,7 +9705,10 @@ SWIGINTERN PyObject *_wrap_SetMinLogLevel(PyObject *self, PyObject *args) {
   arg1 = static_cast< int >(val1);
   {
     try {
-      sentencepiece::SetMinLogLevel(arg1);
+      {
+        ScopedGILRelease release;
+        sentencepiece::SetMinLogLevel(arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9470,7 +9741,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceTrainer__TrainFromString(PyObject *self,
   }
   {
     try {
-      sentencepiece_SentencePieceTrainer__TrainFromString(SWIG_STD_MOVE(arg1));
+      {
+        ScopedGILRelease release;
+        sentencepiece_SentencePieceTrainer__TrainFromString(SWIG_STD_MOVE(arg1));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9518,7 +9792,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceTrainer__TrainFromMap(PyObject *self, Py
   }
   {
     try {
-      sentencepiece_SentencePieceTrainer__TrainFromMap((std::unordered_map< std::string,std::string > const &)*arg1);
+      {
+        ScopedGILRelease release;
+        sentencepiece_SentencePieceTrainer__TrainFromMap((std::unordered_map< std::string,std::string > const &)*arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9582,7 +9859,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceTrainer__TrainFromMap2(PyObject *self, P
   }
   {
     try {
-      sentencepiece_SentencePieceTrainer__TrainFromMap2((std::unordered_map< std::string,std::string > const &)*arg1,arg2);
+      {
+        ScopedGILRelease release;
+        sentencepiece_SentencePieceTrainer__TrainFromMap2((std::unordered_map< std::string,std::string > const &)*arg1,arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9643,7 +9923,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceTrainer__TrainFromMap3(PyObject *self, P
   }
   {
     try {
-      result = sentencepiece_SentencePieceTrainer__TrainFromMap3((std::unordered_map< std::string,std::string > const &)*arg1);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceTrainer__TrainFromMap3((std::unordered_map< std::string,std::string > const &)*arg1);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9710,7 +9993,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceTrainer__TrainFromMap4(PyObject *self, P
   }
   {
     try {
-      result = sentencepiece_SentencePieceTrainer__TrainFromMap4((std::unordered_map< std::string,std::string > const &)*arg1,arg2);
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceTrainer__TrainFromMap4((std::unordered_map< std::string,std::string > const &)*arg1,arg2);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9753,7 +10039,10 @@ SWIGINTERN PyObject *_wrap_new_SentencePieceNormalizer(PyObject *self, PyObject 
   if (!SWIG_Python_UnpackTuple(args, "new_SentencePieceNormalizer", 0, 0, 0)) SWIG_fail;
   {
     try {
-      result = (sentencepiece::SentencePieceNormalizer *)new sentencepiece::SentencePieceNormalizer();
+      {
+        ScopedGILRelease release;
+        result = (sentencepiece::SentencePieceNormalizer *)new sentencepiece::SentencePieceNormalizer();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9784,7 +10073,10 @@ SWIGINTERN PyObject *_wrap_delete_SentencePieceNormalizer(PyObject *self, PyObje
   arg1 = reinterpret_cast< sentencepiece::SentencePieceNormalizer * >(argp1);
   {
     try {
-      delete arg1;
+      {
+        ScopedGILRelease release;
+        delete arg1;
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9825,7 +10117,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer_LoadFromSerializedProto(PyObj
   }
   {
     try {
-      result = (arg1)->LoadFromSerializedProto(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->LoadFromSerializedProto(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9871,7 +10166,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer_LoadFromRuleTSV(PyObject *sel
   }
   {
     try {
-      result = (arg1)->LoadFromRuleTSV(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->LoadFromRuleTSV(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9917,7 +10215,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer_LoadFromRuleName(PyObject *se
   }
   {
     try {
-      result = (arg1)->LoadFromRuleName(SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = (arg1)->LoadFromRuleName(SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9954,7 +10255,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer_serialized_model_proto(PyObje
   arg1 = reinterpret_cast< sentencepiece::SentencePieceNormalizer * >(argp1);
   {
     try {
-      result = ((sentencepiece::SentencePieceNormalizer const *)arg1)->serialized_model_proto();
+      {
+        ScopedGILRelease release;
+        result = ((sentencepiece::SentencePieceNormalizer const *)arg1)->serialized_model_proto();
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -9998,7 +10302,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer_LoadFromFile(PyObject *self, 
   }
   {
     try {
-      result = sentencepiece_SentencePieceNormalizer_LoadFromFile(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceNormalizer_LoadFromFile(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -10044,7 +10351,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer__Normalize(PyObject *self, Py
   }
   {
     try {
-      result = sentencepiece_SentencePieceNormalizer__Normalize(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceNormalizer__Normalize(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -10088,7 +10398,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer__NormalizeWithOffsets(PyObjec
   }
   {
     try {
-      result = sentencepiece_SentencePieceNormalizer__NormalizeWithOffsets(arg1,SWIG_STD_MOVE(arg2));
+      {
+        ScopedGILRelease release;
+        result = sentencepiece_SentencePieceNormalizer__NormalizeWithOffsets(arg1,SWIG_STD_MOVE(arg2));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -10146,7 +10459,10 @@ SWIGINTERN PyObject *_wrap_SentencePieceNormalizer__SetProtoField(PyObject *self
   arg3 = static_cast< bool >(val3);
   {
     try {
-      sentencepiece_SentencePieceNormalizer__SetProtoField(arg1,SWIG_STD_MOVE(arg2),arg3);
+      {
+        ScopedGILRelease release;
+        sentencepiece_SentencePieceNormalizer__SetProtoField(arg1,SWIG_STD_MOVE(arg2),arg3);
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {
@@ -10190,7 +10506,10 @@ SWIGINTERN PyObject *_wrap_SetDataDir(PyObject *self, PyObject *args) {
   }
   {
     try {
-      sentencepiece::SetDataDir(SWIG_STD_MOVE(arg1));
+      {
+        ScopedGILRelease release;
+        sentencepiece::SetDataDir(SWIG_STD_MOVE(arg1));
+      }
       ReleaseResultObject(resultobj);
     }
     catch (const sentencepiece::util::Status &status) {

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -1,7 +1,10 @@
+import os
 import sys
 import threading
 import time
 import sentencepiece as spm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 class HeartbeatCounter:
@@ -32,12 +35,12 @@ def test_gil_release():
   # 1. Generate heavy dummy text data to create enough load
   print("[Main] Generating heavy dummy text...")
   heavy_text = (
-      "Hello, world! Testing SentencePiece GIL release behavior. " * 1000000
+      "Hello, world! Testing SentencePiece GIL release behavior. " * 500000
   )
 
   # 2. Load the pre-trained model
   model_path = "test_model.model"
-  sp = spm.SentencePieceProcessor(model_file=model_path)
+  sp = spm.SentencePieceProcessor(model_file=os.path.join(HERE, model_path))
 
   # 3. Setup the counter and start the background heartbeat thread
   counter = HeartbeatCounter()

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -1,0 +1,99 @@
+import sys
+import threading
+import time
+import sentencepiece as spm
+
+
+class HeartbeatCounter:
+
+  def __init__(self):
+    self.count = 0
+    self._lock = threading.Lock()
+
+  def increment(self):
+    with self._lock:
+      self.count += 1
+
+  def get_count(self):
+    with self._lock:
+      return self.count
+
+
+def background_heartbeat(stop_event, counter):
+  """This thread increments the counter as long as the GIL is properly released."""
+  while not stop_event.is_set():
+    counter.increment()
+    sys.stdout.write(".")
+    sys.stdout.flush()
+    time.sleep(0.01)  # Force context switch
+
+
+def test_gil_release():
+  # 1. Generate heavy dummy text data to create enough load
+  print("[Main] Generating heavy dummy text...")
+  heavy_text = (
+      "Hello, world! Testing SentencePiece GIL release behavior. " * 1000000
+  )
+
+  # 2. Load the pre-trained model
+  model_path = "test_model.model"
+  sp = spm.SentencePieceProcessor(model_file=model_path)
+
+  # 3. Setup the counter and start the background heartbeat thread
+  counter = HeartbeatCounter()
+  stop_event = threading.Event()
+  bg_thread = threading.Thread(
+      target=background_heartbeat, args=(stop_event, counter)
+  )
+  bg_thread.daemon = True
+  bg_thread.start()
+
+  # Wait a brief moment to ensure the background thread spins up
+  time.sleep(0.1)
+
+  # 4. Execute the target C++ action where the GIL should be released
+  print(
+      "\n[Main] Starting SentencePiece encode... (Text length:"
+      f" {len(heavy_text)})",
+      flush=True,
+  )
+  start_time = time.time()
+
+  tokens = sp.encode(heavy_text)
+
+  end_time = time.time()
+  elapsed_time = end_time - start_time
+  print(
+      f"\n[Main] Encode finished. Elapsed time: {elapsed_time:.4f} seconds",
+      flush=True,
+  )
+
+  # 5. Stop and clean up the background thread
+  stop_event.set()
+  bg_thread.join()
+
+  # 6. Validate GIL release by checking the background thread's activity
+  heartbeat_count = counter.get_count()
+  print(
+      f"[Main] Background thread executed {heartbeat_count} times during C++"
+      " execution."
+  )
+
+  # ASSERTION: If the GIL was locked, the background thread wouldn't have executed.
+  # We expect at least a reasonable number of heartbeats based on elapsed time (e.g., > 5 times)
+  min_expected_heartbeats = 100
+
+  assert heartbeat_count >= min_expected_heartbeats, (
+      "GIL Release Failure Detected! The background thread was blocked."
+      f" Expected at least {min_expected_heartbeats} heartbeats, but only got"
+      f" {heartbeat_count}."
+  )
+
+  assert len(tokens) > 0, "Tokenization result is empty"
+  print(
+      "[Main] Test passed successfully! GIL release confirmed programmatically."
+  )
+
+
+if __name__ == "__main__":
+  test_gil_release()

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -82,17 +82,30 @@ def test_gil_release():
       " execution."
   )
 
-  # Calculate expected heartbeats dynamically based on the actual elapsed time.
-  # Loop interval is 0.01s, meaning 100 heartbeats/sec theoretically.
-  # We apply a 50% safety margin to account for OS scheduling fluctuations.
-  sleep_interval = 0.01
-  theoretical_max = elapsed_time / sleep_interval
+  # Check if GIL is explicitly disabled (Python 3.13+ free-threaded build)
+  # sys._is_gil_enabled() returns False in NoGIL (free-threaded) mode.
+  is_gil_disabled = False
+  if hasattr(sys, "_is_gil_enabled"):
+    is_gil_disabled = not sys._is_gil_enabled()
 
-  is_mac = sys.platform == "darwin"
-  # Adjust efficiency margin based on OS
-  # macOS has low timer precision for short sleeps and aggressive core scheduling,
-  # so we lower the expected margin to 10% (0.1). Other OS use 50% (0.5).
-  margin = 0.1 if is_mac else 0.5
+  if is_gil_disabled:
+    print(
+        "[Main] Detected Free-Threaded (NoGIL) environment. True parallelism is"
+        " active."
+    )
+    # In a NoGIL environment, we only need to ensure that the background thread
+    # wasn't completely deadlocked or starved by the native C++ execution.
+    min_expected_heartbeats = 1
+  else:
+    # Standard GIL environment logic
+    is_mac = sys.platform == "darwin"
+    sleep_interval = 0.01
+    theoretical_max = elapsed_time / sleep_interval
+    margin = 0.1 if is_mac else 0.5
+    min_expected_heartbeats = int(theoretical_max * margin)
+
+    if min_expected_heartbeats < 1:
+      min_expected_heartbeats = 1
 
   min_expected_heartbeats = int(theoretical_max * margin)
 

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -107,8 +107,6 @@ def test_gil_release():
     if min_expected_heartbeats < 1:
       min_expected_heartbeats = 1
 
-  min_expected_heartbeats = int(theoretical_max * margin)
-
   # Edge case: If the execution was extremely fast, ensure a floor value of at least 2
   if min_expected_heartbeats < 2:
     min_expected_heartbeats = 2

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -87,7 +87,14 @@ def test_gil_release():
   # We apply a 50% safety margin to account for OS scheduling fluctuations.
   sleep_interval = 0.01
   theoretical_max = elapsed_time / sleep_interval
-  min_expected_heartbeats = int(theoretical_max * 0.5)
+
+  is_mac = sys.platform == "darwin"
+  # Adjust efficiency margin based on OS
+  # macOS has low timer precision for short sleeps and aggressive core scheduling,
+  # so we lower the expected margin to 10% (0.1). Other OS use 50% (0.5).
+  margin = 0.1 if is_mac else 0.5
+
+  min_expected_heartbeats = int(theoretical_max * margin)
 
   # Edge case: If the execution was extremely fast, ensure a floor value of at least 2
   if min_expected_heartbeats < 2:

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -84,7 +84,7 @@ def test_gil_release():
 
   # ASSERTION: If the GIL was locked, the background thread wouldn't have executed.
   # We expect at least a reasonable number of heartbeats based on elapsed time (e.g., > 5 times)
-  min_expected_heartbeats = 100
+  min_expected_heartbeats = 20
 
   assert heartbeat_count >= min_expected_heartbeats, (
       "GIL Release Failure Detected! The background thread was blocked."

--- a/python/test/gil_release_test.py
+++ b/python/test/gil_release_test.py
@@ -82,13 +82,27 @@ def test_gil_release():
       " execution."
   )
 
-  # ASSERTION: If the GIL was locked, the background thread wouldn't have executed.
-  # We expect at least a reasonable number of heartbeats based on elapsed time (e.g., > 5 times)
-  min_expected_heartbeats = 20
+  # Calculate expected heartbeats dynamically based on the actual elapsed time.
+  # Loop interval is 0.01s, meaning 100 heartbeats/sec theoretically.
+  # We apply a 50% safety margin to account for OS scheduling fluctuations.
+  sleep_interval = 0.01
+  theoretical_max = elapsed_time / sleep_interval
+  min_expected_heartbeats = int(theoretical_max * 0.5)
 
+  # Edge case: If the execution was extremely fast, ensure a floor value of at least 2
+  if min_expected_heartbeats < 2:
+    min_expected_heartbeats = 2
+
+  print(
+      f"[Main] Dynamic threshold set to {min_expected_heartbeats} heartbeats"
+      f" (based on {elapsed_time:.4f}s elapsed time)."
+  )
+
+  # ASSERTION
   assert heartbeat_count >= min_expected_heartbeats, (
-      "GIL Release Failure Detected! The background thread was blocked."
-      f" Expected at least {min_expected_heartbeats} heartbeats, but only got"
+      "GIL Release Failure Detected! The background thread was heavily"
+      f" blocked.\nBased on execution time ({elapsed_time:.4f}s), expected at"
+      f" least {min_expected_heartbeats} heartbeats, but only got"
       f" {heartbeat_count}."
   )
 


### PR DESCRIPTION
Release Python GIL while calling C++ API.
This allows to call heavy encoding/training operations independently from the main Python thread.