### PR TITLE
Support parallel encoding

### DIFF
--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -715,13 +715,11 @@ util::Status SentencePieceProcessor::EncodeParallel(absl::string_view input,
 
   // Wait for all encodings to complete and combine results
   EncodeResult combined_result;
-  size_t normalized_offset = 0;
   for (size_t i = 0; i < futures.size(); ++i) {
     const auto chunk_result = futures[i].get();
     for (const auto &piece : chunk_result) {
       combined_result.emplace_back(piece.first, piece.second);
     }
-    normalized_offset += normalized_chunks[i].size();
   }
 
   // Populate the final SentencePieceText
@@ -1256,25 +1254,10 @@ std::vector<absl::string_view> SentencePieceProcessor::SplitInputIntoChunks(
   for (int i = 0; i < num_chunks; ++i) {
     size_t end = (i == num_chunks - 1) ? total_size : start + chunk_size;
 
-    // Ensure we don't split in the middle of a UTF-8 character
+    // Adjust end to not split in the middle of a UTF-8 character
     if (end < total_size) {
-      // Find the next character boundary
-      const char *data = input.data();
-      while (end < total_size && (data[end] & 0x80)) {
-        // If this is a continuation byte, move back
-        if (IsTrailByte(data[end])) {
-          end--;
-        } else {
-          // This is a start byte, so we're at a safe boundary
-          break;
-        }
-      }
-      // If we moved back too far, find the start of the current character
-      if (end > start) {
-        size_t char_len = OneCharLen(data + end);
-        if (end + char_len <= total_size) {
-          end += char_len;
-        }
+      while (end > start && string_util::IsTrailByte(input.data()[end])) {
+        --end;
       }
     }
 

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -17,10 +17,12 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <future>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <set>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -405,6 +407,34 @@ util::Status SentencePieceProcessor::Encode(absl::string_view input,
   return util::OkStatus();
 }
 
+util::Status SentencePieceProcessor::EncodeParallel(
+    absl::string_view input, std::vector<std::string> *pieces, int num_threads) const {
+  CHECK_OR_RETURN_STATUS_STL(pieces);
+
+  SentencePieceText spt;
+  RETURN_IF_ERROR(EncodeParallel(input, &spt, num_threads));
+  for (const auto &sp : spt.pieces()) {
+    pieces->emplace_back(sp.piece());
+  }
+
+  return util::OkStatus();
+}
+
+util::Status SentencePieceProcessor::EncodeParallel(absl::string_view input,
+                                                    std::vector<int> *ids,
+                                                    int num_threads) const {
+  CHECK_OR_RETURN_STATUS_STL(ids);
+
+  SentencePieceText spt;
+  RETURN_IF_ERROR(EncodeParallel(input, &spt, num_threads));
+  ids->reserve(spt.pieces().size());
+  for (const auto &sp : spt.pieces()) {
+    ids->emplace_back(sp.id());
+  }
+
+  return util::OkStatus();
+}
+
 util::Status SentencePieceProcessor::Decode(
     const std::vector<std::string> &pieces, std::string *detokenized) const {
   return Decode(ToPieceArray(pieces), detokenized);
@@ -654,6 +684,48 @@ util::Status SentencePieceProcessor::Encode(absl::string_view input,
       PopulateSentencePieceText(input, normalized, norm_to_orig, result, spt));
 
   return util::OkStatus();
+}
+
+util::Status SentencePieceProcessor::EncodeParallel(absl::string_view input,
+                                                    SentencePieceText *spt,
+                                                    int num_threads) const {
+  CHECK_OR_RETURN_STATUS_PROTO(spt);
+  CHECK_OR_RETURN(num_threads > 0) << "num_threads must be positive";
+
+  // For short inputs or single thread, use regular encoding
+  if (input.size() < 10000 || num_threads == 1) {
+    return Encode(input, spt);
+  }
+
+  // Normalize the entire input first
+  std::string normalized;
+  std::vector<size_t> norm_to_orig;
+  RETURN_IF_ERROR(normalizer_->Normalize(input, &normalized, &norm_to_orig));
+
+  // Split normalized text into chunks
+  std::vector<absl::string_view> normalized_chunks = SplitInputIntoChunks(normalized, num_threads);
+
+  // Encode chunks in parallel
+  std::vector<std::future<EncodeResult>> futures;
+  for (const auto &chunk : normalized_chunks) {
+    futures.emplace_back(std::async(std::launch::async, [this, chunk]() {
+      return this->model_->Encode(chunk);
+    }));
+  }
+
+  // Wait for all encodings to complete and combine results
+  EncodeResult combined_result;
+  size_t normalized_offset = 0;
+  for (size_t i = 0; i < futures.size(); ++i) {
+    const auto chunk_result = futures[i].get();
+    for (const auto &piece : chunk_result) {
+      combined_result.emplace_back(piece.first, piece.second);
+    }
+    normalized_offset += normalized_chunks[i].size();
+  }
+
+  // Populate the final SentencePieceText
+  return PopulateSentencePieceText(input, normalized, norm_to_orig, combined_result, spt);
 }
 
 util::Status SentencePieceProcessor::NBestEncode(
@@ -1167,4 +1239,50 @@ util::Status SaveModelProto(absl::string_view filename,
   return util::OkStatus();
 }
 }  // namespace io
+
+// Helper functions for parallel encoding
+std::vector<absl::string_view> SentencePieceProcessor::SplitInputIntoChunks(
+    absl::string_view input, int num_chunks) const {
+  std::vector<absl::string_view> chunks;
+  if (input.empty() || num_chunks <= 1) {
+    chunks.emplace_back(input);
+    return chunks;
+  }
+
+  const size_t total_size = input.size();
+  const size_t chunk_size = total_size / num_chunks;
+  size_t start = 0;
+
+  for (int i = 0; i < num_chunks; ++i) {
+    size_t end = (i == num_chunks - 1) ? total_size : start + chunk_size;
+
+    // Ensure we don't split in the middle of a UTF-8 character
+    if (end < total_size) {
+      // Find the next character boundary
+      const char *data = input.data();
+      while (end < total_size && (data[end] & 0x80)) {
+        // If this is a continuation byte, move back
+        if (IsTrailByte(data[end])) {
+          end--;
+        } else {
+          // This is a start byte, so we're at a safe boundary
+          break;
+        }
+      }
+      // If we moved back too far, find the start of the current character
+      if (end > start) {
+        size_t char_len = OneCharLen(data + end);
+        if (end + char_len <= total_size) {
+          end += char_len;
+        }
+      }
+    }
+
+    chunks.emplace_back(input.data() + start, end - start);
+    start = end;
+  }
+
+  return chunks;
+}
+
 }  // namespace sentencepiece

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -482,8 +482,10 @@ class SentencePieceProcessor {
 
   virtual std::vector<std::string> EncodeAsPiecesParallel(
       absl::string_view input, int num_threads = 4) const {
-    DEFINE_SPP_DIRECT_FUNC_IMPL(EncodeParallel, std::vector<std::string>, input,
-                                num_threads);
+    std::vector<std::string> output;
+    const auto status = EncodeParallel(input, &output, num_threads);
+    SPP_SWIG_CHECK_AND_THROW;
+    return output;
   }
 
   virtual std::vector<int> EncodeAsIds(absl::string_view input) const {
@@ -492,8 +494,10 @@ class SentencePieceProcessor {
 
   virtual std::vector<int> EncodeAsIdsParallel(absl::string_view input,
                                                int num_threads = 4) const {
-    DEFINE_SPP_DIRECT_FUNC_IMPL(EncodeParallel, std::vector<int>, input,
-                                num_threads);
+    std::vector<int> output;
+    const auto status = EncodeParallel(input, &output, num_threads);
+    SPP_SWIG_CHECK_AND_THROW;
+    return output;
   }
 
   virtual std::vector<std::vector<std::string>> NBestEncodeAsPieces(
@@ -614,8 +618,10 @@ class SentencePieceProcessor {
 
   virtual ImmutableSentencePieceText EncodeAsImmutableProtoParallel(
       absl::string_view input, int num_threads = 4) const {
-    DEFINE_SPP_IMMUTABLE_PROTO_IMPL(EncodeParallel, ImmutableSentencePieceText,
-                                    input, num_threads);
+    ImmutableSentencePieceText output;
+    const auto status = EncodeParallel(input, output.mutable_proto(), num_threads);
+    SPP_SWIG_CHECK_AND_THROW;
+    return output;
   }
 
   virtual ImmutableSentencePieceText SampleEncodeAsImmutableProto(

--- a/src/sentencepiece_processor.h
+++ b/src/sentencepiece_processor.h
@@ -317,6 +317,21 @@ class SentencePieceProcessor {
                               std::string *detokenized) const;
 
   //////////////////////////////////////////////////////////////
+  // Parallel Encode API.
+  //
+  // Given a UTF8 input, encodes it into a sequence of sentence pieces using
+  // parallel processing for improved performance on long texts.
+  virtual util::Status EncodeParallel(absl::string_view input,
+                                      std::vector<std::string> *pieces,
+                                      int num_threads = 4) const;
+
+  // Given a UTF8 input, encodes it into a sequence of ids using parallel
+  // processing for improved performance on long texts.
+  virtual util::Status EncodeParallel(absl::string_view input,
+                                      std::vector<int> *ids,
+                                      int num_threads = 4) const;
+
+  //////////////////////////////////////////////////////////////
   // NBest API.
   //
   // Same as Encode, but returns nbest results.
@@ -406,6 +421,11 @@ class SentencePieceProcessor {
   virtual util::Status Encode(absl::string_view input,
                               SentencePieceText *spt) const;
 
+  // Parallel version of Encode for improved performance on long texts.
+  virtual util::Status EncodeParallel(absl::string_view input,
+                                      SentencePieceText *spt,
+                                      int num_threads = 4) const;
+
   virtual util::Status NBestEncode(absl::string_view input, int nbest_size,
                                    NBestSentencePieceText *nbest_spt) const;
 
@@ -460,8 +480,20 @@ class SentencePieceProcessor {
     DEFINE_SPP_DIRECT_FUNC_IMPL(Encode, std::vector<std::string>, input);
   }
 
+  virtual std::vector<std::string> EncodeAsPiecesParallel(
+      absl::string_view input, int num_threads = 4) const {
+    DEFINE_SPP_DIRECT_FUNC_IMPL(EncodeParallel, std::vector<std::string>, input,
+                                num_threads);
+  }
+
   virtual std::vector<int> EncodeAsIds(absl::string_view input) const {
     DEFINE_SPP_DIRECT_FUNC_IMPL(Encode, std::vector<int>, input);
+  }
+
+  virtual std::vector<int> EncodeAsIdsParallel(absl::string_view input,
+                                               int num_threads = 4) const {
+    DEFINE_SPP_DIRECT_FUNC_IMPL(EncodeParallel, std::vector<int>, input,
+                                num_threads);
   }
 
   virtual std::vector<std::vector<std::string>> NBestEncodeAsPieces(
@@ -578,6 +610,12 @@ class SentencePieceProcessor {
   virtual ImmutableSentencePieceText EncodeAsImmutableProto(
       absl::string_view input) const {
     DEFINE_SPP_IMMUTABLE_PROTO_IMPL(Encode, ImmutableSentencePieceText, input);
+  }
+
+  virtual ImmutableSentencePieceText EncodeAsImmutableProtoParallel(
+      absl::string_view input, int num_threads = 4) const {
+    DEFINE_SPP_IMMUTABLE_PROTO_IMPL(EncodeParallel, ImmutableSentencePieceText,
+                                    input, num_threads);
   }
 
   virtual ImmutableSentencePieceText SampleEncodeAsImmutableProto(
@@ -717,6 +755,10 @@ class SentencePieceProcessor {
       const std::vector<size_t> &norm_to_orig,
       const std::vector<std::pair<absl::string_view, int>> &result,
       SentencePieceText *spt) const;
+
+  // Helper functions for parallel encoding
+  std::vector<absl::string_view> SplitInputIntoChunks(
+      absl::string_view input, int num_chunks) const;
 
   std::unique_ptr<ModelInterface> model_;
   std::unique_ptr<normalizer::Normalizer> normalizer_;

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -415,6 +415,201 @@ TEST(SentencepieceProcessorTest, EncodeTest) {
   }
 }
 
+TEST(SentencepieceProcessorTest, EncodeParallelShortInputTest) {
+  // Short input (< 10000 bytes) should fall back to serial encoding
+  const absl::string_view kInput = WS "ABC" WS "DEF";
+  SentencePieceProcessor sp;
+
+  const auto normalization_spec = MakeDefaultNormalizerSpec();
+
+  auto mock = std::make_unique<MockModel>();
+  const EncodeResult result = {
+      {WS "ABC", 3}, {WS "DE", 4}, {"F", 0}, {"</s>", 2}};
+  mock->SetEncodeResult(kInput, result);
+
+  sp.SetModel(std::move(mock));
+  sp.SetNormalizer(
+      std::make_unique<normalizer::Normalizer>(normalization_spec));
+
+  // Test with multiple threads - should still work correctly
+  {
+    std::vector<std::string> output;
+    EXPECT_TRUE(sp.EncodeParallel("ABC DEF", &output, 4).ok());
+    EXPECT_EQ(GetSpVec(result), output);
+  }
+
+  {
+    std::vector<int> ids;
+    EXPECT_TRUE(sp.EncodeParallel("ABC DEF", &ids, 4).ok());
+    EXPECT_EQ(GetIdVec(result), ids);
+  }
+
+  {
+    SentencePieceText spt;
+    EXPECT_TRUE(sp.EncodeParallel("ABC DEF", &spt, 4).ok());
+    EXPECT_EQ(4, spt.pieces_size());
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_EQ(result[i].first, spt.pieces(i).piece());
+    }
+  }
+
+  // EncodeAsPiecesParallel and EncodeAsIdsParallel
+  {
+    const auto pieces = sp.EncodeAsPiecesParallel("ABC DEF", 4);
+    EXPECT_EQ(GetSpVec(result), pieces);
+  }
+
+  {
+    const auto ids = sp.EncodeAsIdsParallel("ABC DEF", 4);
+    EXPECT_EQ(GetIdVec(result), ids);
+  }
+
+  // EncodeAsImmutableProtoParallel
+  {
+    const auto spt = sp.EncodeAsImmutableProtoParallel("ABC DEF", 4);
+    EXPECT_EQ(4, spt.pieces_size());
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_EQ(result[i].first, spt.pieces(i).piece());
+    }
+  }
+}
+
+TEST(SentencepieceProcessorTest, EncodeParallelSingleThreadTest) {
+  // Single thread should produce same result as serial encoding
+  SentencePieceProcessor sp;
+  const auto normalization_spec = MakeDefaultNormalizerSpec();
+  const absl::string_view kInput = WS "ABC" WS "DEF";
+
+  auto mock = std::make_unique<MockModel>();
+  const EncodeResult result = {
+      {WS "ABC", 3}, {WS "DE", 4}, {"F", 0}, {"</s>", 2}};
+  mock->SetEncodeResult(kInput, result);
+
+  sp.SetModel(std::move(mock));
+  sp.SetNormalizer(
+      std::make_unique<normalizer::Normalizer>(normalization_spec));
+
+  SentencePieceText spt_serial;
+  EXPECT_TRUE(sp.Encode("ABC DEF", &spt_serial).ok());
+
+  SentencePieceText spt_parallel;
+  EXPECT_TRUE(sp.EncodeParallel("ABC DEF", &spt_parallel, 1).ok());
+
+  EXPECT_EQ(spt_serial.SerializeAsString(), spt_parallel.SerializeAsString());
+}
+
+TEST(SentencepieceProcessorTest, EncodeParallelInvalidNumThreadsTest) {
+  SentencePieceProcessor sp;
+  const auto normalization_spec = MakeDefaultNormalizerSpec();
+
+  auto mock = std::make_unique<MockModel>();
+  const EncodeResult result = {{WS "ABC", 3}, {WS "DE", 4}, {"F", 0}, {"</s>", 2}};
+  mock->SetEncodeResult(WS "ABC" WS "DEF", result);
+
+  sp.SetModel(std::move(mock));
+  sp.SetNormalizer(std::make_unique<normalizer::Normalizer>(normalization_spec));
+
+  SentencePieceText spt;
+  // num_threads=0 should fail
+  EXPECT_FALSE(sp.EncodeParallel("ABC DEF", &spt, 0).ok());
+}
+
+// Custom model that tokenizes any input character-by-character (no input verification)
+class CharByCharModel : public ModelInterface {
+ public:
+  CharByCharModel() : ModelInterface() {}
+
+  EncodeResult Encode(absl::string_view normalized) const override {
+    EncodeResult result;
+    for (size_t i = 0; i < normalized.size();) {
+      const size_t char_len = std::max<size_t>(1, static_cast<size_t>(string_util::OneCharLen(normalized.data() + i)));
+      result.emplace_back(
+          absl::string_view(normalized.data() + i, char_len), 3);
+      i += char_len;
+    }
+    return result;
+  }
+
+  int GetPieceSize() const override { return 10; }
+  int PieceToId(absl::string_view piece) const override { return 3; }
+  const std::string &IdToPiece(int id) const override { return kEmptyString; }
+  float GetScore(int id) const override { return 0.0; }
+  bool IsControl(int id) const override { return id == 1 || id == 2; }
+  bool IsUnknown(int id) const override { return id == 0; }
+
+ private:
+  const std::string kEmptyString;
+};
+
+TEST(SentencepieceProcessorTest, EncodeParallelConsistentWithSerialTest) {
+  // Test that parallel encoding produces the same result as serial encoding
+  // for long inputs that exceed the 10KB threshold.
+  const auto normalization_spec = MakeDefaultNormalizerSpec();
+
+  // Build input
+  std::string input;
+  for (int i = 0; i < 5000; ++i) {
+    input += "ABC";
+  }
+  ASSERT_GT(input.size(), 10000);
+
+  SentencePieceProcessor sp;
+  sp.SetModel(std::make_unique<CharByCharModel>());
+  sp.SetNormalizer(std::make_unique<normalizer::Normalizer>(normalization_spec));
+
+  SentencePieceText spt_serial;
+  EXPECT_TRUE(sp.Encode(input, &spt_serial).ok());
+
+  SentencePieceText spt_parallel;
+  EXPECT_TRUE(sp.EncodeParallel(input, &spt_parallel, 4).ok());
+
+  EXPECT_EQ(spt_serial.pieces_size(), spt_parallel.pieces_size());
+  EXPECT_EQ(spt_serial.SerializeAsString(), spt_parallel.SerializeAsString());
+
+  // Verify byte offset consistency
+  for (int i = 0; i < spt_parallel.pieces_size(); ++i) {
+    const auto &piece = spt_parallel.pieces(i);
+    EXPECT_LE(piece.begin(), piece.end());
+    EXPECT_LE(piece.end(), input.size());
+    EXPECT_EQ(input.substr(piece.begin(), piece.end() - piece.begin()), piece.surface());
+  }
+}
+
+TEST(SentencepieceProcessorTest, EncodeParallelMultiByteUtf8Test) {
+  // Test with multi-byte UTF-8 characters across chunk boundaries
+  const auto normalization_spec = MakeDefaultNormalizerSpec();
+
+  // Create input where chunk boundaries may fall in the middle of multi-byte chars
+  std::string input;
+  for (int i = 0; i < 3000; ++i) {
+    input += "あ";  // 3-byte UTF-8 character (9000 bytes)
+  }
+  for (int i = 0; i < 3000; ++i) {
+    input += "a";  // 1-byte ASCII (3000 bytes)
+  }
+  ASSERT_GT(input.size(), 10000);
+
+  SentencePieceProcessor sp;
+  sp.SetModel(std::make_unique<CharByCharModel>());
+  sp.SetNormalizer(std::make_unique<normalizer::Normalizer>(normalization_spec));
+
+  SentencePieceText spt_serial;
+  EXPECT_TRUE(sp.Encode(input, &spt_serial).ok());
+
+  SentencePieceText spt_parallel;
+  EXPECT_TRUE(sp.EncodeParallel(input, &spt_parallel, 4).ok());
+
+  EXPECT_EQ(spt_serial.pieces_size(), spt_parallel.pieces_size());
+  EXPECT_EQ(spt_serial.SerializeAsString(), spt_parallel.SerializeAsString());
+
+  for (int i = 0; i < spt_parallel.pieces_size(); ++i) {
+    const auto &piece = spt_parallel.pieces(i);
+    EXPECT_GE(piece.begin(), 0);
+    EXPECT_GE(piece.end(), piece.begin());
+    EXPECT_LE(piece.end(), input.size());
+  }
+}
+
 TEST(SentencepieceProcessorTest, NBestEncodeTest) {
   const std::string kInput = WS "ABC" WS "DEF";
   SentencePieceProcessor sp;


### PR DESCRIPTION
Support parallel encoding to handle super-long text. When input exceeds 10KB, the text is split into chunks and encoded concurrently using `std::async`, then the results are stitched back together.
## Changes
### `src/sentencepiece_processor.cc`
- **`EncodeParallel(input, pieces, num_threads)`** — new overload returning `vector<string>`
- **`EncodeParallel(input, ids, num_threads)`** — new overload returning `vector<int>`
- **`EncodeParallel(input, spt, num_threads)`** — new overload returning `SentencePieceText` (core implementation)
  - Falls back to serial `Encode()` for inputs <10KB or when `num_threads=1`
  - Normalizes the entire input first, then splits into chunks via `SplitInputIntoChunks`
  - Encodes each chunk with `std::async` and combines results
  - Calls `PopulateSentencePieceText` to build the final output with correct byte offsets
- **`SplitInputIntoChunks(input, num_chunks)`** — new helper that splits text at UTF-8 character boundaries (avoids splitting multi-byte sequences)
- Added `#include <future>` and `#include <thread>`
### `src/sentencepiece_processor.h`
- Added `EncodeParallel` virtual methods (3 overloads) to the public API
- Added convenience wrappers:
  - `EncodeAsPiecesParallel(input, num_threads)`
  - `EncodeAsIdsParallel(input, num_threads)`
  - `EncodeAsImmutableProtoParallel(input, num_threads)`
- Added `SplitInputIntoChunks` as a private helper
### `src/sentencepiece_processor_test.cc`
Added 5 test cases:
| Test | Description |
|------|-------------|
| `EncodeParallelShortInputTest` | Input <10KB falls back to serial; tests all 3 overloads + convenience wrappers |
| `EncodeParallelSingleThreadTest` | `num_threads=1` matches serial `Encode()` |
| `EncodeParallelInvalidNumThreadsTest` | `num_threads=0` returns error |
| `EncodeParallelConsistentWithSerialTest` | 15KB input produces identical results from parallel (4 threads) vs serial |
| `EncodeParallelMultiByteUtf8Test` | 12KB input with 3-byte UTF-8 chars (あ) across chunk boundaries — parallel matches serial |
Also added `CharByCharModel` test stub that tokenizes character-by-character without input verification, enabling parallel-mode testing.
## Implementation Details
- Chunk boundaries are adjusted backward to avoid splitting UTF-8 continuation bytes (`string_util::IsTrailByte`)
- Uses `std::async(std::launch::async, ...)` for thread-safe parallel execution
- Normalization is done once upfront, then chunks work on the normalized text
- Final `PopulateSentencePieceText` maps byte offsets back to original (unnormalized) input
Fixes #1229