### PR TITLE
validate trie and bound value offset in DecompileCharsMap

### DIFF
--- a/src/builder.cc
+++ b/src/builder.cc
@@ -245,14 +245,20 @@ util::Status Builder::DecompileCharsMap(absl::string_view blob,
   trie.set_array(const_cast<char *>(trie_blob.data()),
                  trie_blob.size() / trie.unit_size());
 
+  if (!trie.validate()) {
+    return util::InternalError(
+        "Trie data contains out-of-bounds node references.");
+  }
+
   std::string key;
+  bool value_out_of_range = false;
   std::function<void(size_t, size_t)> traverse;
 
   // Given a Trie node at `node_pos` and the key position at `key_position`,
   // Expands children nodes from `node_pos`.
   // When leaf nodes are found, stores them into `chars_map`.
-  traverse = [&traverse, &key, &trie, &normalized, &chars_map](
-                 size_t node_pos, size_t key_pos) -> void {
+  traverse = [&traverse, &key, &trie, &normalized, &chars_map,
+              &value_out_of_range](size_t node_pos, size_t key_pos) -> void {
     for (int c = 0; c <= 255; ++c) {
       key.push_back(static_cast<char>(c));
       size_t copied_node_pos = node_pos;
@@ -263,13 +269,20 @@ util::Status Builder::DecompileCharsMap(absl::string_view blob,
           key.data(), copied_node_pos, copied_key_pos, key.size());
       if (result >= -1) {   // node exists.
         if (result >= 0) {  // has a value after transition.
-          const absl::string_view value = normalized.data() + result;
-          Chars key_chars, value_chars;
-          for (const auto c : string_util::UTF8ToUnicodeText(key))
-            key_chars.push_back(c);
-          for (const auto c : string_util::UTF8ToUnicodeText(value))
-            value_chars.push_back(c);
-          (*chars_map)[key_chars] = value_chars;
+          // The value is an offset into `normalized`. A crafted charsmap can
+          // store an offset that points past the block, so bound it before
+          // dereferencing.
+          if (static_cast<size_t>(result) >= normalized.size()) {
+            value_out_of_range = true;
+          } else {
+            const absl::string_view value = normalized.data() + result;
+            Chars key_chars, value_chars;
+            for (const auto c : string_util::UTF8ToUnicodeText(key))
+              key_chars.push_back(c);
+            for (const auto c : string_util::UTF8ToUnicodeText(value))
+              value_chars.push_back(c);
+            (*chars_map)[key_chars] = value_chars;
+          }
         }
         // Recursively traverse.
         traverse(copied_node_pos, copied_key_pos);
@@ -279,6 +292,11 @@ util::Status Builder::DecompileCharsMap(absl::string_view blob,
   };
 
   traverse(0, 0);
+
+  if (value_out_of_range) {
+    return util::InternalError(
+        "Normalization rule value offset is out of range.");
+  }
 
   return util::OkStatus();
 }

--- a/src/builder_test.cc
+++ b/src/builder_test.cc
@@ -140,6 +140,47 @@ TEST(BuilderTest, CompileCharsMap) {
   EXPECT_EQ("abcか", normalizer.Normalize("あいうえおか"));
 }
 
+TEST(BuilderTest, DecompileMalformedCharsMapTest) {
+  // Assembles a precompiled charsmap from raw darts units and a normalized
+  // block, matching the on-disk <size><trie><normalized> layout.
+  auto make_blob = [](const std::vector<uint32_t> &units,
+                      absl::string_view normalized) {
+    std::string trie_blob;
+    for (const uint32_t u : units)
+      trie_blob += string_util::EncodePOD<uint32_t>(u);
+    std::string blob = string_util::EncodePOD<uint32_t>(
+        static_cast<uint32_t>(trie_blob.size()));
+    blob += trie_blob;
+    blob.append(normalized.data(), normalized.size());
+    return blob;
+  };
+
+  // A leaf stores an offset into the normalized block. Point it one past the
+  // block: the value must be rejected, not dereferenced.
+  {
+    std::vector<uint32_t> units(256, 0);
+    units[0] = 0x05;                       // root: label 5, no leaf.
+    units[1] = 0x01 | 0x100 | (3u << 10);  // byte 1: label 1, leaf, offset 3.
+    const std::string normalized("abc\0", 4);
+    units[2] = 0x80000000u | static_cast<uint32_t>(normalized.size());
+    Builder::CharsMap chars_map;
+    EXPECT_FALSE(
+        Builder::DecompileCharsMap(make_blob(units, normalized), &chars_map)
+            .ok());
+  }
+
+  // A node whose child base lies outside the array must be rejected before it
+  // is walked.
+  {
+    std::vector<uint32_t> units(256, 0);
+    units[5] = 0x3FFu << 10;  // non-leaf unit with an out-of-range offset.
+    Builder::CharsMap chars_map;
+    EXPECT_FALSE(Builder::DecompileCharsMap(
+                     make_blob(units, std::string("x\0", 2)), &chars_map)
+                     .ok());
+  }
+}
+
 static constexpr char kTestInputData[] = "nfkc.tsv";
 
 TEST(BuilderTest, LoadCharsMapTest) {


### PR DESCRIPTION
DecompileCharsMap takes the precompiled charsmap from a model's NormalizerSpec and walks it with darts, but unlike the normaliser's own load path it neither validates the double-array nor bounds-checks the value held at each leaf. Feed `spm_normalize --decompile` a model whose precompiled_charsmap is crafted and two things go wrong: the traversal can step onto nodes outside the array, and on reaching a leaf it uses the stored 31-bit value verbatim as an offset into the normalised block, so `normalized.data() + result` is passed to UTF8ToUnicodeText and strlen runs off the end of the buffer. I reproduced it by replaying the same traverse loop over a 256-unit trie built by hand, with one leaf whose value equals normalized.size(); the offset lands one past the block and the read wanders into unrelated heap.

Normalizer::Init already guards the hot path with trie.validate(), and NormalizePrefix already drops any value that is >= normalized_.size() before it dereferences, so the decompiler was simply missing both. The bound has to sit here because the offset is attacker-controlled data that only exists once it has been pulled back out of the trie, so no caller can vet it beforehand. Left as is, a third-party model inspected with --decompile gives an out-of-bounds read off the heap.
