### PR TITLE
bound commonPrefixSearch result count to buffer size in normalizer

### DIFF
--- a/src/normalizer.cc
+++ b/src/normalizer.cc
@@ -208,9 +208,16 @@ std::pair<absl::string_view, int> Normalizer::NormalizePrefix(
     Darts::DoubleArray::result_pair_type
         trie_results[Normalizer::kMaxTrieResultsSize];
 
-    const size_t num_nodes = trie_->commonPrefixSearch(
-        input.data(), trie_results, Normalizer::kMaxTrieResultsSize,
-        input.size());
+    // commonPrefixSearch returns the total number of matches, which can be
+    // larger than the buffer size (see darts.h). A precompiled charsmap loaded
+    // from an untrusted model is not subject to the build-time
+    // kMaxTrieResultsSize check, so cap the count to the buffer capacity before
+    // indexing trie_results.
+    const size_t num_nodes = std::min<size_t>(
+        trie_->commonPrefixSearch(input.data(), trie_results,
+                                  Normalizer::kMaxTrieResultsSize,
+                                  input.size()),
+        Normalizer::kMaxTrieResultsSize);
 
     // Finds the longest rule.
     for (size_t k = 0; k < num_nodes; ++k) {
@@ -340,8 +347,9 @@ int PrefixMatcher::PrefixMatch(absl::string_view w, bool *found) const {
 
   constexpr int kResultSize = 64;
   Darts::DoubleArray::result_pair_type trie_results[kResultSize];
-  const int num_nodes =
-      trie_->commonPrefixSearch(w.data(), trie_results, kResultSize, w.size());
+  const int num_nodes = std::min<int>(
+      trie_->commonPrefixSearch(w.data(), trie_results, kResultSize, w.size()),
+      kResultSize);
 
   if (found) *found = (num_nodes > 0);
   if (num_nodes == 0) {

--- a/src/normalizer.h
+++ b/src/normalizer.h
@@ -97,6 +97,7 @@ class Normalizer {
 
  private:
   FRIEND_TEST(NormalizerTest, EncodeDecodePrecompiledCharsMapTest);
+  FRIEND_TEST(NormalizerTest, ManySharedPrefixesTest);
 
   void Init();
 

--- a/src/normalizer_test.cc
+++ b/src/normalizer_test.cc
@@ -421,12 +421,10 @@ TEST(NormalizerTest, ManySharedPrefixesTest) {
   std::string normalized_block = "a";
   normalized_block += '\0';
 
-  // <trie size (4-byte little-endian uint32)><trie><normalized>
-  std::string blob;
-  const uint32_t tsize = static_cast<uint32_t>(trie_blob.size());
-  blob.append(reinterpret_cast<const char *>(&tsize), sizeof(tsize));
-  blob.append(trie_blob.data(), trie_blob.size());
-  blob.append(normalized_block.data(), normalized_block.size());
+  // EncodePrecompiledCharsMap stores the blob in little-endian, matching how a
+  // real model proto is serialised, so the test works on big-endian hosts too.
+  const std::string blob =
+      Normalizer::EncodePrecompiledCharsMap(trie_blob, normalized_block);
 
   NormalizerSpec spec;
   spec.set_precompiled_charsmap(blob);

--- a/src/normalizer_test.cc
+++ b/src/normalizer_test.cc
@@ -14,11 +14,14 @@
 
 #include "normalizer.h"
 
+#include <set>
+#include <string>
 #include <vector>
 
 #include "builder.h"
 #include "sentencepiece_trainer.h"
 #include "testharness.h"
+#include "third_party/darts_clone/darts.h"
 #include "util.h"
 
 namespace sentencepiece {
@@ -391,6 +394,70 @@ TEST(NormalizerTest, EncodeDecodePrecompiledCharsMapTest) {
   EXPECT_FALSE(Normalizer::DecodePrecompiledCharsMap("", &trie_blob,
                                                      &normalized_blob, &buf)
                    .ok());
+}
+
+TEST(NormalizerTest, ManySharedPrefixesTest) {
+  // A precompiled charsmap loaded from a model is not subject to the
+  // build-time kMaxTrieResultsSize check, so its trie may have more
+  // shared-prefix rules than the on-stack result buffer can hold. Normalizing
+  // an input that matches all of them must not read past the buffer.
+  // More than Normalizer::kMaxTrieResultsSize (32) shared-prefix rules.
+  const int kNumKeys = 40;
+  std::vector<std::string> keys;
+  std::vector<const char *> kptr;
+  std::vector<int> values;
+  for (int i = 1; i <= kNumKeys; ++i) keys.emplace_back(std::string(i, 'a'));
+  for (auto &k : keys) {
+    kptr.push_back(k.c_str());
+    values.push_back(0);
+  }
+
+  Darts::DoubleArray trie;
+  ASSERT_EQ(0, trie.build(kptr.size(), const_cast<char **>(kptr.data()),
+                          nullptr, values.data()));
+  absl::string_view trie_blob(static_cast<const char *>(trie.array()),
+                              trie.size() * trie.unit_size());
+
+  std::string normalized_block = "a";
+  normalized_block += '\0';
+
+  // <trie size (4-byte little-endian uint32)><trie><normalized>
+  std::string blob;
+  const uint32_t tsize = static_cast<uint32_t>(trie_blob.size());
+  blob.append(reinterpret_cast<const char *>(&tsize), sizeof(tsize));
+  blob.append(trie_blob.data(), trie_blob.size());
+  blob.append(normalized_block.data(), normalized_block.size());
+
+  NormalizerSpec spec;
+  spec.set_precompiled_charsmap(blob);
+  spec.set_add_dummy_prefix(false);
+  spec.set_remove_extra_whitespaces(false);
+  spec.set_escape_whitespaces(false);
+
+  const Normalizer normalizer(spec);
+  ASSERT_TRUE(normalizer.status().ok());
+  // Matches all kNumKeys nested rules at position 0. Every rule maps to the
+  // single-character normalized form "a", so the output only contains 'a'.
+  const std::string input(kNumKeys, 'a');
+  const std::string output = normalizer.Normalize(input);
+  EXPECT_FALSE(output.empty());
+  EXPECT_EQ(std::string(output.size(), 'a'), output);
+}
+
+TEST(PrefixMatcherTest, ManySharedPrefixesTest) {
+  // PrefixMatcher builds its trie from a model's user-defined symbols, which
+  // can also exceed the on-stack result buffer.
+  std::vector<std::string> keys;
+  for (int i = 1; i <= 70; ++i) keys.emplace_back(std::string(i, 'b'));
+  std::set<absl::string_view> dic(keys.begin(), keys.end());
+
+  const PrefixMatcher matcher(dic);
+  bool found = false;
+  const std::string input(70, 'b');
+  const int mblen = matcher.PrefixMatch(input, &found);
+  EXPECT_TRUE(found);
+  EXPECT_GT(mblen, 0);
+  EXPECT_LE(mblen, static_cast<int>(input.size()));
 }
 
 TEST(NormalizerTest, StatusTest) {


### PR DESCRIPTION
**Stack over-read in the normalizer trie lookups**

While running the normaliser under AddressSanitizer against a model whose `precompiled_charsmap` I had crafted by hand, ASAN flagged a stack-buffer-overflow read in `NormalizePrefix`, at the loop that scans `trie_results`. The on-stack array holds `kMaxTrieResultsSize` (32) entries, but `Darts::DoubleArray::commonPrefixSearch` returns the total number of prefix matches and only writes up to the buffer capacity (documented in darts.h), so the loop walks off the end of the array whenever a query position has more than 32 shared-prefix rules. The build path is safe because `CompileCharsMap` rejects maps that exceed that count, yet a `precompiled_charsmap` read straight out of a model proto never goes through that check, so the invariant the comment relies on is not actually present for loaded models. `PrefixMatcher::PrefixMatch` has the same shape with a 64-entry buffer fed from the model's user-defined symbols and over-reads identically once there are more than 64 nested symbols.

The root cause is treating the search return value as the number of entries written rather than a possibly larger match total. The fix caps the count to the buffer capacity at both sites before it is used as a loop bound. Left unfixed this is an out-of-bounds read reachable from any untrusted model (via `spm_normalize` or `SentencePieceProcessor::Load`), leaking adjacent stack into the selected rule and potentially crashing the process. I reproduced both over-reads under ASAN using tries of 40 and 70 nested keys; the added regression tests exercise both paths and the full suite passes clean afterwards.
