### PR TITLE
reject out-of-bounds root unit in DoubleArray::validate

### DIFF
--- a/src/normalizer.h
+++ b/src/normalizer.h
@@ -99,6 +99,7 @@ class Normalizer {
  private:
   FRIEND_TEST(NormalizerTest, EncodeDecodePrecompiledCharsMapTest);
   FRIEND_TEST(NormalizerTest, ManySharedPrefixesTest);
+  FRIEND_TEST(NormalizerTest, MalformedRootUnitTest);
 
   void Init();
 

--- a/src/normalizer_test.cc
+++ b/src/normalizer_test.cc
@@ -14,6 +14,8 @@
 
 #include "normalizer.h"
 
+#include <cstdint>
+#include <cstring>
 #include <set>
 #include <string>
 #include <vector>
@@ -442,6 +444,46 @@ TEST(NormalizerTest, ManySharedPrefixesTest) {
   const std::string output = normalizer.Normalize(input);
   EXPECT_FALSE(output.empty());
   EXPECT_EQ(std::string(output.size(), 'a'), output);
+}
+
+TEST(NormalizerTest, MalformedRootUnitTest) {
+  // commonPrefixSearch() and traverse() always follow the root unit's offset()
+  // before inspecting any label, but validate() skips units whose MSB label bit
+  // is set. A precompiled charsmap loaded from a model whose root unit has that
+  // bit set together with a large offset must be rejected at construction;
+  // otherwise the first prefix lookup reads past the trie array.
+  std::vector<std::string> keys = {"a", "ab", "abc"};
+  std::vector<const char*> kptr;
+  std::vector<int> values;
+  for (auto& k : keys) {
+    kptr.push_back(k.c_str());
+    values.push_back(0);
+  }
+
+  Darts::DoubleArray trie;
+  ASSERT_EQ(0, trie.build(kptr.size(), const_cast<char**>(kptr.data()), nullptr,
+                          values.data()));
+  std::string trie_blob(static_cast<const char*>(trie.array()),
+                        trie.size() * trie.unit_size());
+
+  // Corrupt the root unit: set its MSB label bit (so validate() would skip it)
+  // and a large offset field that points outside the array.
+  const uint32_t bad_root = 0x80000000u | (0x00040000u << 10);
+  std::memcpy(&trie_blob[0], &bad_root, sizeof(bad_root));
+
+  std::string normalized_block = "a";
+  normalized_block += '\0';
+  const std::string blob =
+      Normalizer::EncodePrecompiledCharsMap(trie_blob, normalized_block);
+
+  NormalizerSpec spec;
+  spec.set_precompiled_charsmap(blob);
+  spec.set_add_dummy_prefix(false);
+  spec.set_remove_extra_whitespaces(false);
+  spec.set_escape_whitespaces(false);
+
+  const Normalizer normalizer(spec);
+  EXPECT_FALSE(normalizer.status().ok());
 }
 
 TEST(PrefixMatcherTest, ManySharedPrefixesTest) {

--- a/third_party/darts_clone/darts.h
+++ b/third_party/darts_clone/darts.h
@@ -437,6 +437,16 @@ bool DoubleArrayImpl<A, B, T, C>::validate() const {
   if (size_ == 0) {
     return true;
   }
+  // commonPrefixSearch()/traverse() always follow the root unit's offset()
+  // before inspecting any label, so the root must be a real node. The loop
+  // below skips units whose MSB label bit is set, which would otherwise let a
+  // crafted root unit (MSB set, large offset) slip through and make the first
+  // transition read out of bounds. Validate the root explicitly, as open()
+  // does, using the same in-bounds rule as the loop.
+  if (array_[0].label() != '\0' || array_[0].has_leaf() ||
+      array_[0].offset() == 0 || (array_[0].offset() | 0xFF) >= size_) {
+    return false;
+  }
   for (std::size_t i = 0; i < size_; ++i) {
     // Leaf/value units store data in the offset field, not child pointers.
     // label() has MSB set (> 0xFF) for these units. Skip them, matching


### PR DESCRIPTION
Loading a model whose `normalizer_spec.precompiled_charsmap` is attacker controlled can read out of bounds during normalisation. The charsmap is a darts double-array deserialised straight from the proto, and `Normalizer::Init` guards it with `Darts::DoubleArray::validate()`. Whilst tracing an ASAN `BUS` fault in `NormalizePrefix` (`commonPrefixSearch` at normalizer.cc:218) I found that `validate()` skips any unit whose MSB label bit is set, treating it as a leaf/value unit. The root unit (index 0) is special: `commonPrefixSearch()` and `traverse()` always follow its `offset()` before they inspect any label, so a root unit with the MSB set and a large offset field passes `validate()` and the very first transition indexes far outside the array. The model loads cleanly and the fault only surfaces on the first `Encode`/`Normalize`, or via `spm_normalize --decompile` (`DecompileCharsMap` then `traverse`). Left unpatched this is an attacker controlled out-of-bounds read reachable from any untrusted `.model` file.

`open()` already rejects a malformed root the same way (label must be `\0`, no leaf bit, offset in range); `validate()` simply never carried that check across, so both `Init` and `DecompileCharsMap` inherit the gap. I added the root check inside `validate()` using the same in-bounds rule the loop applies to every other node, which fixes both call sites with one guard. I verified it with a fuzzer that mutates a compiled charsmap and then normalises: the `BUS` fault reproduces on the unpatched tree and is gone afterwards, every embedded charsmap (`nfkc`, `nmt_nfkc`, `nfkc_cf`, ...) still loads and encodes, and the existing normalizer and builder tests stay green. `NormalizerTest.MalformedRootUnitTest` corrupts the root unit and asserts the model is rejected; it fails before the change and passes after.
