### PR TITLE
respect buffer strides in CastToVectorInt to avoid OOB read

### DIFF
--- a/python/src/sentencepiece/sentencepiece_pybind.cc
+++ b/python/src/sentencepiece/sentencepiece_pybind.cc
@@ -313,17 +313,32 @@ std::vector<int> CastToVectorInt(const py::object& ids_obj) {
       if (info.ndim != 1) {
         throw py::type_error("Buffer must be 1-dimensional");
       }
-      ids.resize(info.shape[0]);
-      if (info.itemsize == 4) {
-        std::memcpy(ids.data(), info.ptr, info.shape[0] * 4);
-      } else if (info.itemsize == 8) {
-        const int64_t* src = static_cast<const int64_t*>(info.ptr);
-        for (size_t i = 0; i < info.shape[0]; ++i) {
-          ids[i] = static_cast<int>(src[i]);
-        }
-      } else {
+      if (info.itemsize != 4 && info.itemsize != 8) {
         throw py::type_error(
             "Unsupported buffer integer size (must be 32-bit or 64-bit)");
+      }
+      ids.resize(info.shape[0]);
+      // A buffer obtained with strides may be non-contiguous: a numpy slice or
+      // a reversed `a[::-1]` view reports a data pointer to its first logical
+      // element with a stride that is not equal to itemsize (negative for the
+      // reversed case). Reading info.shape[0] items straight off info.ptr then
+      // walks past the allocation, so step by info.strides[0] instead.
+      const py::ssize_t stride =
+          info.strides.empty() ? info.itemsize : info.strides[0];
+      const char* base = static_cast<const char*>(info.ptr);
+      if (info.itemsize == 4) {
+        if (stride == info.itemsize) {
+          std::memcpy(ids.data(), info.ptr, info.shape[0] * 4);
+        } else {
+          for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
+            ids[i] = *reinterpret_cast<const int32_t*>(base + i * stride);
+          }
+        }
+      } else {  // info.itemsize == 8
+        for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
+          const auto* p = reinterpret_cast<const int64_t*>(base + i * stride);
+          ids[i] = static_cast<int>(*p);
+        }
       }
       return ids;
     } catch (const py::error_already_set&) {

--- a/python/test/numpy_test.py
+++ b/python/test/numpy_test.py
@@ -124,6 +124,25 @@ class TestNumpyIntegration(unittest.TestCase):
         decoded_64 = self.sp.decode(ids_2d_64)
         self.assertEqual(decoded_64, [text, text])
 
+    def test_decode_numpy_non_contiguous(self):
+        text = "This is a test sentence."
+        ids = self.sp.encode(text, return_type=int)
+
+        for dtype in (np.int32, np.int64):
+            arr = np.array(ids, dtype=dtype)
+
+            # Reversed view: negative stride, data pointer at the last element.
+            reversed_view = arr[::-1]
+            self.assertFalse(reversed_view.flags['C_CONTIGUOUS'])
+            self.assertEqual(self.sp.decode(reversed_view),
+                             self.sp.decode(list(ids[::-1])))
+
+            # Strided slice: stride larger than itemsize.
+            strided = arr[::2]
+            self.assertFalse(strided.flags['C_CONTIGUOUS'])
+            self.assertEqual(self.sp.decode(strided),
+                             self.sp.decode(list(ids[::2])))
+
     def test_decode_numpy_invalid_types(self):
         # Float array should fail
         ids_float = np.array([1.0, 2.0], dtype=np.float32)


### PR DESCRIPTION
Whilst tracing an `IndexError: piece id is out of range` raised by `decode()` on a reversed numpy array, I found the id buffer being read as though it were contiguous. `CastToVectorInt` requests the buffer with strides, so numpy hands over non-contiguous views without copying, but the read then ignores `info.strides`: the 32-bit branch does a flat `memcpy` of `shape[0] * 4` bytes from `info.ptr`, and the 64-bit branch walks `src[i]` from `info.ptr`. A reversed view `a[::-1]` reports a data pointer to its last element with a stride of `-itemsize`, so reading `shape[0]` items forward runs `(shape[0]-1) * itemsize` bytes off the end of the allocation. Under AddressSanitizer this shows up as a heap-buffer-overflow read; without it the stray bytes come back as decoded ids, which is how the out-of-range id surfaced.

The buffer paths feed every id-based decode entry point (`_DecodeIds`, `_DecodeIdsAsBytes`, `_DecodeIdsAsImmutableProto`, `_Normalize`, and the batch variants via `CastToVectorVectorInt`), so any caller passing a sliced or reversed array reads out of bounds. Left unfixed it is a heap over-read reachable from the public decode/normalize API whenever the id array is not contiguous.

1. the buffer is requested with strides but read as if C-contiguous, so a reversed or sliced view points past its own data.
2. step by `info.strides[0]` in both itemsize branches, keeping the `memcpy` fast path only when `stride == itemsize`.

Testing: added `test_decode_numpy_non_contiguous` for reversed and strided int32/int64 id arrays. It fails on the current code (out-of-range id) and passes with the change; the existing numpy and processor tests stay green.
