### PR TITLE
Update Dockerfile since #1244: upgrade alpine image to 3.24

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23 AS build
+FROM alpine:3.24 AS build
 
 RUN apk add --no-cache \
     linux-headers \
@@ -23,7 +23,7 @@ RUN cd /workspace && \
 
 # ---
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 ENV PATH="/usr/local/bin:${PATH}"
 COPY --from=build /usr/local /usr/local


### PR DESCRIPTION
This PR is a continuation of #1244.

Alpine Linux released 3.24 (stable) in June 9, 2026. See <https://alpinelinux.org/posts/Alpine-3.24.0-released.html> for the release note. See <https://hub.docker.com/_/alpine> about the Docker image. Hence, this pull request upgrades the alpine image from `3.23` to `3.24`.

The test run of the Dockerfile can be checked at <https://github.com/kkew3/sentencepiece_dockerfile/actions/runs/27868349942/job/82476049260?pr=19>.