### PR TITLE
Fix Decode() of empty input for non-str return types (proto crash, wrong type for bytes/serialized_proto)

### DIFF
--- a/python/src/sentencepiece/__init__.py
+++ b/python/src/sentencepiece/__init__.py
@@ -526,13 +526,14 @@ class SentencePieceProcessor:
         return raw_val
 
     def _decode_raw(self, input, return_type, num_threads, thread_pool, return_bytes=False):
+        # Normalize empty input to an empty id sequence and fall through to the
+        # regular dispatch below, so that the result comes from the C++ method
+        # and is typed according to return_type (e.g. bytes for
+        # return_type=bytes or 'serialized_proto'), matching non-empty inputs.
         if input is None:
-            return ''
-        if _is_sequence(input):
-            if len(input) == 0:
-                return ''
+            input = []
         elif isinstance(input, (str, bytes)) and len(input) == 0:
-            return ''
+            input = []
 
         # Helper to determine if a sequence contains pieces (str/bytes)
         def _is_pieces(seq):
@@ -551,7 +552,7 @@ class SentencePieceProcessor:
         if hasattr(input, 'ndim'):
             is_batch = input.ndim > 1
         else:
-            is_batch = _is_sequence(input[0])
+            is_batch = len(input) > 0 and _is_sequence(input[0])
 
         # Determine if input contains pieces (str/bytes)
         if is_batch:

--- a/python/test/sentencepiece_test.py
+++ b/python/test/sentencepiece_test.py
@@ -102,6 +102,26 @@ class TestSentencepieceProcessor(unittest.TestCase):
     with self.assertRaises(IndexError):
       self.sp_.DecodeIds([10000])
 
+  def test_decode_empty_input(self):
+    # Empty input must return a value typed according to return_type,
+    # matching the non-empty code path.
+    for empty in ([], None):
+      self.assertEqual(self.sp_.decode(empty, return_type=str), '')
+      self.assertEqual(self.sp_.decode(empty, return_type=bytes), b'')
+      serialized = self.sp_.decode(empty, return_type='serialized_proto')
+      self.assertEqual(type(serialized), bytes)
+      offsets = self.sp_.decode(empty, return_type='offset_mapping')
+      self.assertIsInstance(offsets, dict)
+      self.assertEqual(offsets['text'], '')
+      self.assertEqual(offsets['ids'], [])
+      self.assertEqual(offsets['pieces'], [])
+      self.assertEqual(offsets['offsets'], [])
+      if has_protobuf:
+        proto = self.sp_.decode(empty, return_type='proto')
+        self.assertIsInstance(proto, sentencepiece_pb2.SentencePieceText)
+        self.assertEqual(proto.text, '')
+        self.assertEqual(len(proto.pieces), 0)
+
   def test_roundtrip(self):
     text = 'I saw a girl with a telescope.'
     ids = self.sp_.EncodeAsIds(text)


### PR DESCRIPTION
### Describe the change

`SentencePieceProcessor._decode_raw()` short-circuits empty/`None` input by returning the literal `str` `''` for every `return_type`. The `str` case happens to be correct, but the other return types are broken:

- `Decode([], return_type='proto')` crashes: the `str` `''` is passed to `SentencePieceText.ParseFromString()`, which raises `TypeError: expected bytes, str found`.
- `Decode([], return_type=bytes)` returns `str` `''` instead of `b''` (the non-empty path returns `bytes`).
- `Decode([], return_type='serialized_proto')` returns `str` `''` instead of the serialized empty proto (`bytes`).

**Root cause:** the empty-input guard in `_decode_raw()` hardcodes `return ''` and ignores the `return_type` argument, bypassing the correctly-typed empty results the C++ layer already produces (`_DecodeIdsAsBytes([])` returns `b''`, `_DecodeIdsAsSerializedProto([])` returns a valid serialized empty `SentencePieceText`).

**Fix:** instead of returning a hardcoded `''`, normalize empty/`None` input to an empty id sequence and fall through to the regular dispatch, so the result comes from the C++ method and is typed according to `return_type` — exactly like non-empty input. The batch check now guards `input[0]` with `len(input) > 0`. No behavior change for any non-empty input, and the default `return_type=str` still returns `''` for empty input.

### Link to a related Issue

Fixes #1288

### Testing Information

Added `test_decode_empty_input` to `python/test/sentencepiece_test.py`, covering `Decode([])` and `Decode(None)` for `return_type` in `{str, bytes, 'serialized_proto', 'proto', 'offset_mapping'}`. Without the fix it fails with `TypeError: expected bytes, str found` on the `'proto'` case (and the `bytes` type assertions); with the fix it passes.

Ran the full Python test suite with the extension built in place (`python3.11 setup.py build_ext --inplace`):

```
PYTHONPATH=src python3.11 -m pytest test/sentencepiece_test.py test/numpy_test.py -q
```

All tests pass (58 passed), including the numpy suite, confirming no regression on single/batch id/piece decoding or empty numpy arrays.
