### PR TITLE
Update Dockerfile since #1276: add libgomp to runtime dependencies

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -29,5 +29,6 @@ ENV PATH="/usr/local/bin:${PATH}"
 COPY --from=build /usr/local /usr/local
 
 # Add runtime dependencies.
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+RUN apk add --no-cache libgomp && \
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     gperftools-dev tcmalloc


### PR DESCRIPTION
This PR is a continuation of #1276.

Commit fd53b5c3a5f96f753425ee68e596a4cccdebbc9e introduced `-lgomp` flag for linux:

```diff
diff --git a/python/setup.py b/python/setup.py
index 60e0811..0af8a9e 100755
--- a/python/setup.py
+++ b/python/setup.py
@@ -131,6 +131,7 @@ class build_ext_unix(_build_ext):
       # GNU linker
       libs.append('-Wl,--start-group')
       libs.extend(abseil_libs)
+      libs.append('-lgomp')
       libs.append('-Wl,--end-group')
       libs.append('-Wl,--gc-sections')
       libs.append('-Wl,--version-script=exports.txt')
@@ -143,6 +144,9 @@ class build_ext_unix(_build_ext):
 
     if sys.platform == 'linux':
       libs.append('-Wl,-Bsymbolic')
+      libs.append('-fopenmp')
+      libs.append('-lgomp')
+      cflags.append('-fopenmp')
 
     if is_gil_disabled():
       cflags.append('-DPy_GIL_DISABLED')
```

Hence, we need to update the runtime dependencies as well.

The test run of the Dockerfile can be checked at https://github.com/kkew3/sentencepiece_dockerfile/actions/runs/31021739631/job/92359882631?pr=20.