### PR TITLE
Take darts-clone from the Bazel Central Registry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,13 @@ module(
 
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.2")
+
+# darts-clone is header-only. The Bazel build takes it from the Bazel Central
+# Registry; 0.32h.bcr.1 is upstream v0.32h plus the copy_array()/validate()
+# helpers that third_party/darts_clone/darts.h carries, so the API SentencePiece
+# uses is identical. The vendored copy is still what the CMake build compiles.
+bazel_dep(name = "darts-clone", version = "0.32h.bcr.1")
+
 # libsais is compiled from C sources. The Bazel build takes it from the Bazel
 # Central Registry; 2.10.4 is the same upstream release the vendored
 # third_party/libsais copy is a reformatted snapshot of. The vendored copy is

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -84,6 +84,8 @@
     "https://bcr.bazel.build/modules/boringssl/0.20260413.0/source.json": "4e954245542ed32b91b08d25af1a54f1df29be2e1e9c09b94eead351e3cef36b",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
+    "https://bcr.bazel.build/modules/darts-clone/0.32h.bcr.1/MODULE.bazel": "348f81ae7e268eddcd7bc3afc7b0eb2db9463ace8cd13d66d1d93e00f472eb0e",
+    "https://bcr.bazel.build/modules/darts-clone/0.32h.bcr.1/source.json": "2f63a2d747b3c5e722b0b8127cf1b3b36277b126dde171f13aa025a5a343d466",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -90,7 +90,7 @@ cc_library(
         ":config",
         ":sentencepiece_cc_proto",
         ":sentencepiece_model_cc_proto",
-        "//third_party:darts_clone",
+        "@darts-clone//:darts-clone",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/cleanup",
@@ -150,7 +150,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":sentencepiece_processor",
-        "//third_party:darts_clone",
+        "@darts-clone//:darts-clone",
         "@libsais",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:fixed_array",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,9 @@ endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../third_party)
+# darts.h is included unqualified so that the Bazel build can serve it from the
+# darts-clone module; the CMake build keeps compiling the vendored copy.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../third_party/darts_clone)
 # libsais.h is included unqualified so that the Bazel build can serve it from
 # the libsais module; the CMake build keeps compiling the vendored copy.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libsais)
@@ -209,6 +212,7 @@ target_include_directories(sentencepiece-static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/darts_clone>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_include_directories(sentencepiece_train-static PUBLIC
@@ -217,6 +221,7 @@ target_include_directories(sentencepiece_train-static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/darts_clone>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
@@ -237,6 +242,7 @@ if (SPM_ENABLE_SHARED)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/darts_clone>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
   target_include_directories(sentencepiece_train PUBLIC
@@ -245,6 +251,7 @@ if (SPM_ENABLE_SHARED)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/darts_clone>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
   add_library(sentencepiece::sentencepiece ALIAS sentencepiece)

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -39,7 +39,7 @@
 #include "filesystem.h"
 #include "normalizer.h"
 #include "ret_check.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 #include "util.h"
 
 #ifdef ENABLE_NFKC_COMPILE

--- a/src/model_interface.cc
+++ b/src/model_interface.cc
@@ -33,7 +33,7 @@
 #include "absl/strings/string_view.h"
 #include "normalizer.h"
 #include "sentencepiece_model.pb.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 #include "util.h"
 
 namespace sentencepiece {

--- a/src/model_interface.h
+++ b/src/model_interface.h
@@ -30,7 +30,7 @@
 #include "normalizer.h"
 #include "sentencepiece_model.pb.h"
 #include "sentencepiece_processor.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 
 namespace sentencepiece {
 

--- a/src/normalizer.cc
+++ b/src/normalizer.cc
@@ -31,7 +31,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "ret_check.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 #include "util.h"
 
 namespace sentencepiece {

--- a/src/normalizer.h
+++ b/src/normalizer.h
@@ -26,7 +26,7 @@
 #include "gtest_prod.h"
 #include "sentencepiece_model.pb.h"
 #include "sentencepiece_processor.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 
 namespace sentencepiece::normalizer {
 

--- a/src/normalizer_test.cc
+++ b/src/normalizer_test.cc
@@ -25,7 +25,7 @@
 #include "absl/strings/string_view.h"
 #include "builder.h"
 #include "sentencepiece_trainer.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 #include "util.h"
 
 namespace sentencepiece {

--- a/src/unigram_model.h
+++ b/src/unigram_model.h
@@ -25,7 +25,7 @@
 #include "freelist.h"
 #include "model_interface.h"
 #include "sentencepiece_model.pb.h"
-#include "third_party/darts_clone/darts.h"
+#include "darts.h"
 
 namespace sentencepiece {
 namespace unigram {

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,9 +1,0 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-package(default_visibility = ["//:__subpackages__"])
-
-cc_library(
-    name = "darts_clone",
-    hdrs = ["darts_clone/darts.h"],
-    includes = ["."],
-)


### PR DESCRIPTION
The Bazel build depends on the [`darts-clone` BCR module](https://registry.bazel.build/modules/darts-clone) instead of compiling `third_party/darts_clone/darts.h`. The CMake build is unchanged and still compiles the vendored copy.

## `0.32h.bcr.1` vs. `third_party/darts_clone/darts.h`

Both declare `DARTS_VERSION "0.32"` and both carry the `copy_array()` and `validate(max_value_limit)` helpers this repo added — the module's `darts_header_compat.patch` is derived from those, and its compat test cites commit `d685ef31`. `diff` between the two headers is 108 lines:

| | vendored | `0.32h.bcr.1` |
|---|---|---|
| `copy_array()` | ✓ | ✓ |
| `validate(max_value_limit)` | ✓ | ✓ |
| `commonLongestPrefixSearch()` | ✗ | ✓ |
| `save()` `offset` argument | ignored (unnamed parameter) | honoured via `fseek` |
| `BLOCK_SIZE`, `UPPER_MASK`, … | `static constexpr int` | `enum` |
| `size_t` → `id_type` narrowing | implicit | explicit `static_cast` |

The vendored copy predates the `v0.32h` tag, which is where `commonLongestPrefixSearch()` and the `save()` offset fix landed; the module is that tag plus the two helpers above. The remaining differences are the `enum`/`constexpr` spelling, the added `static_cast`s, and `validate()`'s `else { if }` rewritten as `else if` — same semantics.

SentencePiece calls `build`, `set_array`, `copy_array`, `validate`, `exactMatchSearch`, `commonPrefixSearch`, `traverse`, `array` and `size`. All behave identically. `commonLongestPrefixSearch()` and `save()` are never called, so the two additions are inert here.

## Why the module rather than the vendored header

**Known provenance.** The module records exactly what it is: `s-yata/darts-clone` `v0.32h`, pinned by SHA-256 of the release tarball, plus four named patches that are themselves hash-pinned. `third_party/darts_clone/darts.h` is an undated snapshot of an unrecorded revision with local edits folded in — the only way to learn what was changed, as the table above shows, is to diff it against upstream and guess which side each difference came from.

**Upgrades become a version bump.** The vendored copy has drifted behind `v0.32h` and silently lost the `save()` offset fix along the way. Moving it forward today means re-applying the two helpers by hand onto a new upstream drop and re-reviewing the result; with the module it is one line in `MODULE.bazel`, and the helpers travel as a patch that fails loudly if it stops applying.

**One copy per build.** Bazel consumers that depend on both SentencePiece and darts-clone currently get two `Darts::DoubleArray` definitions from two include paths. Going through the registry lets minimal version selection resolve them to a single copy, which matters for a header-only library whose types cross the ABI boundary in `normalizer.h` and `model_interface.h`.

**The helpers are covered.** The module ships `darts_clone_compat_test.cc`, which exercises `validate()` and `copy_array()` — the two additions this repo depends on — so a bad patch rebase is caught in the registry's presubmit rather than here.

**Visible in dependency tooling.** A `bazel_dep` with a version appears in `MODULE.bazel.lock`, `bazel mod graph`, and any SBOM generated from them. A checked-in header does not.

The vendored copy is not deleted: the CMake build still compiles it, so this change reduces the number of builds that depend on the unlabelled snapshot from two to one rather than to zero. Retiring it entirely would mean giving CMake its own way to fetch darts-clone, which is out of scope here.

## Include path

The module exports the header as `darts.h` (`strip_include_prefix = "include"`), so the seven `#include "third_party/darts_clone/darts.h"` lines lose the prefix. `src/CMakeLists.txt` gains `third_party/darts_clone` on its include path so the CMake build resolves the same spelling against the vendored copy.

Verified locally on macOS/arm64: `bazel test //...` 22/22 pass, `cmake --build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
