### PR TITLE
build: upgrade MSVC and common C++ standard from C++17 to C++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # Common C++ settings
-build --cxxopt=-std=c++17
+build --cxxopt=-std=c++20
 
 # Linux / GCC / Clang
 build:linux --copt=-Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,7 @@ set_property(CACHE SPM_PROTOBUF_PROVIDER PROPERTY STRINGS "module" "package")
 # ==============================================================================
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# MSVC C++20 STL has an issue with Protobuf v25.6's UntypedMessage in
-# std::variant (error C2139). Use C++17 under MSVC for Abseil and Protobuf.
-# See: https://github.com/protocolbuffers/protobuf/issues/21310
-if (MSVC)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 20)
-endif()
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
@@ -234,7 +227,16 @@ if (SPM_PROTOBUF_PROVIDER STREQUAL "module")
     GIT_TAG v36.0
     GIT_SHALLOW TRUE
   )
+  # MSVC C++20 STL has an issue with Protobuf's UntypedMessage in
+  # std::variant (error C2139). Scope C++17 under MSVC specifically to Protobuf.
+  # See: https://github.com/protocolbuffers/protobuf/issues/21310
+  if (MSVC)
+    set(CMAKE_CXX_STANDARD 17)
+  endif()
   FetchContent_MakeAvailable(protobuf)
+  if (MSVC)
+    set(CMAKE_CXX_STANDARD 20)
+  endif()
 
   if (SPM_PROTOC_EXECUTABLE)
     if (NOT TARGET protobuf::protoc)

--- a/doc/bazel.md
+++ b/doc/bazel.md
@@ -5,7 +5,7 @@ In addition to the [CMake build](cli.md), SentencePiece can be built with [Bazel
 ## Prerequisites
 
 - [Bazel](https://bazel.build) 7.2.1 or later (Bazel 7, 8, 9 supported; installing via [Bazelisk](https://github.com/bazelbuild/bazelisk) is recommended)
-- A C++17 compatible compiler (GCC, Clang, or MSVC)
+- A C++20 compatible compiler (GCC, Clang, or MSVC)
 
 ## Building
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -11,7 +11,7 @@ This document describes how to build and install the SentencePiece C++ libraries
 The following tools and libraries are required to build SentencePiece:
 
 - **CMake** (3.14 or later)
-- **C++20 compiler** (e.g., GCC 11+, Clang 13+, or MSVC 2019+ with C++17)
+- **C++20 compiler** (e.g., GCC 11+, Clang 13+, or MSVC 2019+ with C++20)
 - **gperftools** library (optional, provides a 10-40% performance improvement)
 
 ### Building from Source (Linux/macOS)

--- a/python/setup.py
+++ b/python/setup.py
@@ -205,7 +205,7 @@ class build_ext_win(_build_ext):
       ])
       build_dir = '.\\build'
 
-    cflags = ['/std:c++17'] + get_build_includes(build_dir, is_msvc=True)
+    cflags = ['/std:c++20'] + get_build_includes(build_dir, is_msvc=True)
     libs = [
         os.path.join(build_dir, 'root', 'lib', 'sentencepiece.lib'),
         os.path.join(build_dir, 'root', 'lib', 'sentencepiece_train.lib'),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,11 +217,7 @@ target_include_directories(sentencepiece_train-static PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if (MSVC)
-  set(SPM_CXX_STANDARD_FEATURE cxx_std_17)
-else()
-  set(SPM_CXX_STANDARD_FEATURE cxx_std_20)
-endif()
+set(SPM_CXX_STANDARD_FEATURE cxx_std_20)
 
 target_compile_features(sentencepiece-static PUBLIC ${SPM_CXX_STANDARD_FEATURE})
 target_compile_features(sentencepiece_train-static PUBLIC ${SPM_CXX_STANDARD_FEATURE})


### PR DESCRIPTION
Upgrade the MSVC C++ language standard to C++20 across CMake, Python setup, and Bazel build configurations.

Scope C++17 under MSVC specifically to Protobuf's FetchContent build to prevent a known MSVC C++20 std::variant compile error on UntypedMessage (error C2139, protobuf #21310).

Changes:
- CMakeLists.txt: Set CMAKE_CXX_STANDARD to 20 for SentencePiece, and scope C++17 specifically to Protobuf under MSVC.
- src/CMakeLists.txt: Set SPM_CXX_STANDARD_FEATURE to cxx_std_20.
- python/setup.py: Use /std:c++20 instead of /std:c++17 for MSVC build.
- .bazelrc: Set --cxxopt=-std=c++20.
- doc/bazel.md, doc/cli.md: Update documentation to reflect C++20 compiler requirement.
