### PR TITLE
Decode batch starting with an empty sequence was misclassified

### DIFF
--- a/python/src/sentencepiece/__init__.py
+++ b/python/src/sentencepiece/__init__.py
@@ -554,9 +554,18 @@ class SentencePieceProcessor:
         else:
             is_batch = len(input) > 0 and _is_sequence(input[0])
 
-        # Determine if input contains pieces (str/bytes)
+        # Determine if input contains pieces (str/bytes).
+        # An empty sequence (no ids / no pieces) is ambiguous, so for a batch we
+        # infer the element type from the first non-empty inner sequence.
+        # Without this, a piece batch that starts with an empty sentence (e.g.
+        # produced by encoding an empty string) is mistaken for an id batch and
+        # decode() fails with an unrelated TypeError.
         if is_batch:
-            input_is_pieces = _is_pieces(input[0])
+            input_is_pieces = False
+            for item in input:
+                if _is_sequence(item) and len(item) > 0:
+                    input_is_pieces = _is_pieces(item)
+                    break
         else:
             input_is_pieces = _is_pieces(input)
 

--- a/python/src/sentencepiece/sentencepiece_pybind.cc
+++ b/python/src/sentencepiece/sentencepiece_pybind.cc
@@ -1138,9 +1138,6 @@ PYBIND11_MODULE(_sentencepiece, m, py::mod_gil_not_used()) {
            [](const sentencepiece::SentencePieceProcessor& self,
               const py::list& ins, int num_threads, py::object thread_pool) {
              if (ins.empty()) return py::list();
-             py::list sublist0 = ins[0].cast<py::list>();
-             if (sublist0.empty()) return py::list();
-             bool is_bytes = py::isinstance<py::bytes>(sublist0[0]);
 
              std::vector<PyListStringViewVector> C_ins_wrappers;
              C_ins_wrappers.reserve(ins.size());
@@ -1159,6 +1156,18 @@ PYBIND11_MODULE(_sentencepiece, m, py::mod_gil_not_used()) {
                    *pool.get());
                if (!status.ok()) throw status;
              }
+
+             // Empty sequences (e.g. a sentence that encoded to no pieces) are
+             // valid and decode to an empty string, so where they appear in the
+             // batch must not change the result. Determine the output element
+             // type (str/bytes) from the first non-empty sequence.
+             bool is_bytes = false;
+             for (size_t i = 0; i < ins.size(); ++i) {
+               if (C_ins[i].empty()) continue;
+               is_bytes = py::isinstance<py::bytes>(ins[i].cast<py::list>()[0]);
+               break;
+             }
+
              py::list py_outs(outs.size());
              for (size_t i = 0; i < outs.size(); ++i) {
                py_outs[i] = ToPyString(outs[i], is_bytes);
@@ -1251,21 +1260,27 @@ PYBIND11_MODULE(_sentencepiece, m, py::mod_gil_not_used()) {
              bool is_pieces_batch = false;
              bool detected_bytes = false;
 
-             if (!py_ins.empty()) {
-               py::object first_seq = py_ins[0];
-               if (py::isinstance<py::list>(first_seq) ||
-                   py::isinstance<py::tuple>(first_seq)) {
-                 py::sequence inner_seq = first_seq;
-                 if (!inner_seq.empty()) {
-                   py::object first_item = inner_seq[0];
-                   if (py::isinstance<py::str>(first_item)) {
-                     is_pieces_batch = true;
-                   } else if (py::isinstance<py::bytes>(first_item)) {
-                     is_pieces_batch = true;
-                     detected_bytes = true;
-                   }
-                 }
+             // A batch may start with empty sequences (e.g. a sentence that
+             // encoded to no pieces / no ids). Empty sequences carry no type
+             // information, so infer the element type from the first non-empty
+             // inner sequence; otherwise a piece batch that starts with an empty
+             // sequence would be decoded as an id batch.
+             for (size_t i = 0; i < py_ins.size(); ++i) {
+               py::object seq = py_ins[i];
+               if (!py::isinstance<py::list>(seq) &&
+                   !py::isinstance<py::tuple>(seq)) {
+                 continue;
                }
+               py::sequence inner_seq = seq;
+               if (inner_seq.empty()) continue;
+               py::object first_item = inner_seq[0];
+               if (py::isinstance<py::str>(first_item)) {
+                 is_pieces_batch = true;
+               } else if (py::isinstance<py::bytes>(first_item)) {
+                 is_pieces_batch = true;
+                 detected_bytes = true;
+               }
+               break;
              }
 
              if (is_pieces_batch) {

--- a/python/test/sentencepiece_test.py
+++ b/python/test/sentencepiece_test.py
@@ -118,6 +118,44 @@ class TestSentencepieceProcessor(unittest.TestCase):
         self.assertEqual(proto.text, '')
         self.assertEqual(len(proto.pieces), 0)
 
+  def test_decode_batch_with_leading_empty_sequence(self):
+    # A batch may contain empty sequences (e.g. an empty sentence encoded to
+    # zero pieces/ids). The batch element type (pieces vs ids) is inferred from
+    # the first non-empty sequence, so a leading empty sequence must not make a
+    # piece batch be decoded as an id batch. Regression test: an empty sequence
+    # at the start used to fail while the same empty sequence at the end worked.
+    sp = self.sp_
+    text = 'hello world'
+    ids = sp.encode(text, return_type=int)
+    pieces = sp.encode(text, return_type=str)
+    pieces_bytes = [p.encode('utf-8') for p in pieces]
+
+    # Empty sequence at the end (already worked).
+    self.assertEqual(sp.decode([ids, []]), [text, ''])
+    self.assertEqual(sp.decode([pieces, []], return_type=str), [text, ''])
+    self.assertEqual(
+        sp.decode([pieces_bytes, []], return_type=bytes), [text.encode(), b'']
+    )
+
+    # Empty id sequence at the start.
+    self.assertEqual(sp.decode([[], ids]), ['', text])
+
+    # Empty piece sequence at the start.
+    self.assertEqual(sp.decode([[], pieces], return_type=str), ['', text])
+    self.assertEqual(
+        sp.decode([[], pieces_bytes], return_type=bytes), [b'', text.encode()]
+    )
+
+    # offset_mapping must produce the same result for both orders.
+    empty_om = sp.decode([], return_type='offset_mapping')
+    text_om = sp.decode(pieces, return_type='offset_mapping')
+    self.assertEqual(
+        sp.decode([pieces, []], return_type='offset_mapping'), [text_om, empty_om]
+    )
+    self.assertEqual(
+        sp.decode([[], pieces], return_type='offset_mapping'), [empty_om, text_om]
+    )
+
   def test_roundtrip(self):
     text = 'I saw a girl with a telescope.'
     ids = self.sp_.EncodeAsIds(text)


### PR DESCRIPTION
decode() figures out whether a batch holds ids or pieces from the first inner sequence. An empty sequence carries no type information, so a piece batch that starts with an empty sentence (e.g. an empty string that encoded to zero pieces) was treated as an id batch and blew up with a TypeError about integer input, while the same empty sequence at the end of the batch decoded fine.

This makes the batch element type be inferred from the first non-empty inner sequence instead, in both the Python dispatch and the two C++ batch methods that re-derive the type internally:

- _DecodePiecesBatch no longer returns [] (dropping the whole batch) when the first sub-list is empty; the str/bytes output type is taken from the first non-empty sub-list.
- _DecodeAsOffsetMappingBatch no longer falls back to id decoding when the first sub-list is empty.

Added regression tests for ids, str pieces, bytes pieces and offset_mapping, asserting that a leading empty sequence decodes the same as a trailing one. Verified dispatch-level routing with a stubbed _sentencepiece module (all scenarios route to the intended C++ method); full python test suite requires a built extension.