### PR TITLE
reject out-of-range id in SentencePieceProcessor id accessors

### DIFF
--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -1039,6 +1039,9 @@ int SentencePieceProcessor::PieceToId(absl::string_view piece) const {
 const std::string& SentencePieceProcessor::IdToPiece(int id) const {
   static const std::string* kEmptyString = new std::string;
   RET_CHECK_OR_RETURN_DEFAULT(*kEmptyString);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return *kEmptyString;
+  }
   return model_->IdToPiece(id);
 }
 
@@ -1053,26 +1056,41 @@ bool SentencePieceProcessor::SafeIdToPiece(int id, std::string* piece) const {
 
 float SentencePieceProcessor::GetScore(int id) const {
   RET_CHECK_OR_RETURN_DEFAULT(0.0);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return 0.0;
+  }
   return model_->GetScore(id);
 }
 
 bool SentencePieceProcessor::IsControl(int id) const {
   RET_CHECK_OR_RETURN_DEFAULT(0);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return false;
+  }
   return model_->IsControl(id);
 }
 
 bool SentencePieceProcessor::IsUnknown(int id) const {
   RET_CHECK_OR_RETURN_DEFAULT(0);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return false;
+  }
   return model_->IsUnknown(id);
 }
 
 bool SentencePieceProcessor::IsUnused(int id) const {
   RET_CHECK_OR_RETURN_DEFAULT(false);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return false;
+  }
   return model_->IsUnused(id);
 }
 
 bool SentencePieceProcessor::IsByte(int id) const {
   RET_CHECK_OR_RETURN_DEFAULT(false);
+  if (id < 0 || id >= model_->GetPieceSize()) {
+    return false;
+  }
   return model_->IsByte(id);
 }
 

--- a/src/sentencepiece_processor_test.cc
+++ b/src/sentencepiece_processor_test.cc
@@ -1048,6 +1048,16 @@ TEST(SentencePieceProcessorTest, EndToEndTest) {
   EXPECT_EQ(2, sp.eos_id());
   EXPECT_EQ(-1, sp.pad_id());
 
+  // Out-of-range ids must not read past the piece array.
+  for (const int id : {-1, sp.GetPieceSize(), sp.GetPieceSize() + 100}) {
+    EXPECT_EQ("", sp.IdToPiece(id));
+    EXPECT_NEAR(0.0, sp.GetScore(id), 0.001);
+    EXPECT_FALSE(sp.IsUnknown(id));
+    EXPECT_FALSE(sp.IsControl(id));
+    EXPECT_FALSE(sp.IsUnused(id));
+    EXPECT_FALSE(sp.IsByte(id));
+  }
+
   {
     std::vector<std::string> sps;
     const std::vector<std::string> expected_str = {WS, "ab", "c"};


### PR DESCRIPTION
The public id accessors on `SentencePieceProcessor` (`IdToPiece`, `GetScore`, `IsControl`, `IsUnknown`, `IsUnused`, `IsByte`) forward their `id` straight to the model layer, which lands on `model_proto_->pieces(id)` guarded only by `DCHECK`. In a release build (`NDEBUG`) that check is compiled out, so an `id` outside `[0, GetPieceSize())` walks off the piece array. I noticed the asymmetry while reading the accessors: `SafeIdToPiece` and `Decode(absl::Span<const int>)` both range-check the id against `GetPieceSize()`, but these six siblings do not, even though they take the same untrusted id surface (token ids arriving from a caller or a model server). Building with `-fsanitize=address`, `sp.GetScore(sp.GetPieceSize())` aborts with a SEGV in `ModelInterface::GetScore` (`model_interface.h`) as the stray `RepeatedPtrField` element pointer is dereferenced; without instrumentation it silently returns garbage or crashes. Left unfixed this is a memory-safety fault reachable from any code path that queries a model-supplied or client-supplied id.

The fix adds the same `[0, GetPieceSize())` guard the safe siblings already use, inside each accessor, returning that method's existing not-loaded default when the id is out of range. Keeping the bound in the accessor rather than expecting every caller to pre-validate matches `SafeIdToPiece` and stops the public API being driven past the end of the array. The added case in `EndToEndTest` exercises `-1`, `GetPieceSize()` and a far past-the-end id across all six accessors; it SEGVs on the current tree under ASan and passes with the guard, and the full `ctest` suite stays green.