### PR TITLE
guard empty piece before exactMatchSearch in unigram PieceToId

### DIFF
--- a/src/unigram_model.cc
+++ b/src/unigram_model.cc
@@ -604,6 +604,13 @@ int Model::PieceToId(absl::string_view piece) const {
   if (it != reserved_id_map_.end()) {
     return it->second;
   }
+  // An empty piece has no id and must resolve to <unk>. exactMatchSearch()
+  // treats length 0 as "key is a zero-terminated C string" and scans
+  // piece.data() forward until a NUL, so forwarding piece.size() == 0 reads
+  // past the (empty) view: for a view over non-terminated bytes it runs off
+  // the buffer, and for a zero-length view over live data it spuriously
+  // matches a following key.
+  if (piece.empty()) return unk_id_;
   int id = 0;
   trie_->exactMatchSearch(piece.data(), id, piece.size());
   return id == -1 ? unk_id_ : id;

--- a/src/unigram_model_test.cc
+++ b/src/unigram_model_test.cc
@@ -529,6 +529,28 @@ TEST(UnigramModelTest, PieceToIdTest) {
   EXPECT_TRUE(model.Encode("").empty());
 }
 
+TEST(UnigramModelTest, PieceToIdEmptyPieceTest) {
+  ModelProto model_proto = MakeBaseModelProto();
+
+  AddPiece(&model_proto, "a", 0.1);   // 3
+  AddPiece(&model_proto, "b", 0.2);   // 4
+  AddPiece(&model_proto, "ab", 0.3);  // 5
+
+  Model model(model_proto);
+
+  // A zero-length piece has no id and must resolve to <unk>, like the base
+  // ModelInterface::PieceToId map lookup. A zero-length view whose data()
+  // points at real bytes must not be matched as if it were the underlying
+  // key: exactMatchSearch() reads length 0 as C-string mode and scans forward.
+  EXPECT_EQ(0, model.PieceToId(""));
+  EXPECT_EQ(0, model.PieceToId(absl::string_view("ab", 0)));
+  EXPECT_EQ(0, model.PieceToId(absl::string_view("a", 0)));
+
+  // Non-empty lookups are unaffected.
+  EXPECT_EQ(3, model.PieceToId("a"));
+  EXPECT_EQ(5, model.PieceToId("ab"));
+}
+
 TEST(UnigramModelTest, PopulateNodesAllUnknownsTest) {
   ModelProto model_proto = MakeBaseModelProto();
   AddPiece(&model_proto, "x");


### PR DESCRIPTION
While tracing why an empty token round-tripped to a real vocabulary id, I found `unigram::Model::PieceToId` forwarding `piece.size()` straight into `Darts::DoubleArray::exactMatchSearch`. As darts.h documents, a length of 0 is not "match zero bytes" but "the key is a zero-terminated C string", so the search abandons the length entirely and scans `piece.data()` forward until it meets a NUL. For an empty piece that means it reads whatever lies at and after `data()`: a zero-length view onto live bytes spuriously matches the following key (an empty field from `absl::StrSplit` in `spm_decode --input_format=piece`, or a caller-supplied `absl::string_view` slice, comes back as a non-`<unk>` id), and a view onto a non-terminated buffer runs off the end. I reproduced the latter directly against a darts trie under AddressSanitizer and it reports a `heap-buffer-overflow` READ inside the C-string scan; the base `ModelInterface::PieceToId` never has this problem because it resolves empty pieces through its hash map.

The root cause is passing an untrusted length of 0 to an API whose zero has special meaning, so the fix returns `unk_id_` for an empty piece before the trie is touched. That matches the base-class contract and the existing `PieceToId("")` expectation, adds no work on the normal path, and leaves every non-empty lookup untouched. Left unfixed this is an out-of-bounds read reachable from the public decode surface, and a correctness bug that silently turns empty tokens into arbitrary vocabulary ids. The added `PieceToIdEmptyPieceTest` fails on the current code (an empty view over `"ab"` returns 5) and passes with the change.
